### PR TITLE
Add Jql support

### DIFF
--- a/lib/jira.rb
+++ b/lib/jira.rb
@@ -5,6 +5,8 @@ ActiveSupport::Inflector.inflections do |inflector|
   inflector.singular 'status', 'status'
 end
 
+require 'uri'
+
 require 'jira/base'
 require 'jira/base_factory'
 require 'jira/has_many_proxy'

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -29,11 +29,14 @@ module JIRA
 
       has_many :worklogs, :nested_under => ['fields','worklog']
 
-      def self.all(client)
+      def self.all(client, jql = nil)
         issues = []
         fetched_results = 0
         begin 
-          response = client.get(client.options[:rest_base_path] + "/search")
+          url = client.options[:rest_base_path] + "/search?startAt=#{fetched_results}"
+          url << "&jql=#{ URI.escape(jql) }" if jql
+
+          response = client.get(url)
           json = parse_json(response.body)
           
           issues = issues + json['issues'].map do |issue|

--- a/lib/jira/resource/project.rb
+++ b/lib/jira/resource/project.rb
@@ -16,12 +16,16 @@ module JIRA
       end
 
       # Returns all the issues for this project
-      def issues
+      def issues(jql = nil)
        
         issues = []
         fetched_results = 0
-        begin 
-          response = client.get(client.options[:rest_base_path] + "/search?jql=project%3D'#{key}'&startAt=#{fetched_results}")
+        begin
+          uri = client.options[:rest_base_path] + "/search?startAt=#{fetched_results}"
+          uri << "&jql=project%3D'#{key}'"
+          uri << URI.escape(" and #{jql}") if jql
+
+          response = client.get(uri)
           json = self.class.parse_json(response.body)
           
           issues = issues + json['issues'].map do |issue|


### PR DESCRIPTION
It seems that it would be super valuable (and it is to me) to have jql support when looking for issues. Having JQL support will allow the caller to window down the issues that they are looking at without having to look at every issues under the sun (slow, painful and silly). I have modified two functions. On the Issues class I have added a new variable to the class method _all_ which will allow the call to specify JQL, I have also update the instance method on issues to allow the caller to pass in jql for the _issues_ instance method. 

I though about adding a search method to issues, but could not convince myself that it was the right thing to do.

Thoughts?
