### PR TITLE
Allows JIRA context path to be set using options.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -184,12 +184,13 @@ Here's the same example as a Sinatra application:
     before do
       options = {
         :site               => 'http://localhost:2990',
+        :context_path       => '/jira',
         :signature_method   => 'RSA-SHA1',
-        :request_token_path => "/jira/plugins/servlet/oauth/request-token",
-        :authorize_path     => "/jira/plugins/servlet/oauth/authorize",
-        :access_token_path  => "/jira/plugins/servlet/oauth/access-token",
+        :request_token_path => "/plugins/servlet/oauth/request-token",
+        :authorize_path     => "/plugins/servlet/oauth/authorize",
+        :access_token_path  => "/plugins/servlet/oauth/access-token",
         :private_key_file   => "rsakey.pem",
-        :rest_base_path     => "/jira/rest/api/2"
+        :rest_base_path     => "/rest/api/2"
       }
 
       @jira_client = JIRA::Client.new('jira-ruby-example', '', options)

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -11,12 +11,13 @@ module JIRA
   # are:
   #
   #   :site               => 'http://localhost:2990',
+  #   :context_path       => '/jira',
   #   :signature_method   => 'RSA-SHA1',
-  #   :request_token_path => "/jira/plugins/servlet/oauth/request-token",
-  #   :authorize_path     => "/jira/plugins/servlet/oauth/authorize",
-  #   :access_token_path  => "/jira/plugins/servlet/oauth/access-token",
+  #   :request_token_path => "/plugins/servlet/oauth/request-token",
+  #   :authorize_path     => "/plugins/servlet/oauth/authorize",
+  #   :access_token_path  => "/plugins/servlet/oauth/access-token",
   #   :private_key_file   => "rsakey.pem",
-  #   :rest_base_path     => "/jira/rest/api/2"
+  #   :rest_base_path     => "/rest/api/2"
   #
   #
   # See the JIRA::Base class methods for all of the available methods on these accessor
@@ -44,16 +45,23 @@ module JIRA
 
     DEFAULT_OPTIONS = {
       :site               => 'http://localhost:2990',
+      :context_path       => '/jira',
       :signature_method   => 'RSA-SHA1',
-      :request_token_path => "/jira/plugins/servlet/oauth/request-token",
-      :authorize_path     => "/jira/plugins/servlet/oauth/authorize",
-      :access_token_path  => "/jira/plugins/servlet/oauth/access-token",
+      :request_token_path => "/plugins/servlet/oauth/request-token",
+      :authorize_path     => "/plugins/servlet/oauth/authorize",
+      :access_token_path  => "/plugins/servlet/oauth/access-token",
       :private_key_file   => "rsakey.pem",
-      :rest_base_path     => "/jira/rest/api/2"
+      :rest_base_path     => "/rest/api/2"
     }
 
     def initialize(consumer_key, consumer_secret, options={})
       options = DEFAULT_OPTIONS.merge(options)
+
+      # prepend the context path to all authorization and rest paths
+      options[:request_token_path] = options[:context_path] + options[:request_token_path]
+      options[:authorize_path] = options[:context_path] + options[:authorize_path]
+      options[:access_token_path] = options[:context_path] + options[:access_token_path]
+      options[:rest_base_path] = options[:context_path] + options[:rest_base_path]
 
       @options = options
       @options.freeze

--- a/spec/jira/client_spec.rb
+++ b/spec/jira/client_spec.rb
@@ -22,9 +22,10 @@ describe JIRA::Client do
     subject.secret.should == 'bar'
   end
 
-  it "sets the default options" do
-    JIRA::Client::DEFAULT_OPTIONS.each do |key, value|
-      subject.options[key].should == value
+  it "sets the non path default options" do
+    options = [:site, :signature_method, :private_key_file]
+    options.each do |key|
+      subject.options[key].should == JIRA::Client::DEFAULT_OPTIONS[key]
     end
   end
 
@@ -32,15 +33,15 @@ describe JIRA::Client do
     # Check it overrides a given option ...
     client = JIRA::Client.new('foo', 'bar', :site => 'http://foo.com/')
     client.options[:site].should == 'http://foo.com/'
-
-    # ... but leaves the rest intact
-    JIRA::Client::DEFAULT_OPTIONS.keys.reject do |key|
-      key == :site
-    end.each do |key|
-      client.options[key].should == JIRA::Client::DEFAULT_OPTIONS[key]
-    end
-
     JIRA::Client::DEFAULT_OPTIONS[:site].should_not == 'http://foo.com/'
+  end
+
+  it "prepends the context path to all authorization and rest paths" do
+    options = [:request_token_path, :authorize_path, :access_token_path, :rest_base_path]
+    defaults = JIRA::Client::DEFAULT_OPTIONS
+    options.each do |key|
+      subject.options[key].should == defaults[:context_path] + defaults[key]
+    end
   end
 
   # To avoid having to validate options after initialisation, e.g. setting


### PR DESCRIPTION
JIRA admins can specify the context path of an instance of JIRA.
This option lets one specify the context path to align accordingly.
