### PR TITLE
JIRA::Client can init using OAuth or Basic Auth

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,7 +5,7 @@ API version 2).
 
 == Example usage
 
-  client = JIRA::Client.new(CONSUMER_KEY, CONSUMER_SECRET)
+  client = JIRA::Client.new({:consumer_key => CONSUMER_KEY, :consumer_secret => CONSUMER_SECRET})
 
   project = client.Project.find('SAMPLEPROJECT')
 
@@ -70,9 +70,47 @@ key.
   After you have entered all the information click OK and ensure OAuth authentication is
   enabled.
 
+== Configuring JIRA to use HTTP Basic Auth
+
+Follow the same steps described above to set up a new Application Link in JIRA,
+however there is no need to set up any "incoming authentication" as this
+defaults to HTTP Basic Auth.
+
+== Using the API Gem in a command line application
+
+Using HTTP Basic Authentication, configure and connect a client to your instance
+of JIRA.
+
+  require 'rubygems'
+  require 'pp'
+  require 'jira'
+
+  # Consider the use of :use_ssl and :ssl_verify_mode options if running locally 
+  # for tests.
+
+  username = "myremoteuser"
+  password = "myuserspassword"
+
+  options = {
+              :username => username,
+              :password => password,
+              :site     => 'http://localhost:8080/',
+              :context_path => '/myjira',
+              :auth_type => :basic
+            }
+
+  client = JIRA::Client.new(options)
+
+  # Show all projects
+  projects = client.Project.all
+  
+  projects.each do |project|
+    puts "Project -> key: #{project.key}, name: #{project.name}"
+  end
+
 == Using the API Gem in your Rails application
 
-The gem requires the consumer key and public certificate file (which
+Using oauth, the gem requires the consumer key and public certificate file (which
 are generated in their respective rake tasks) to initialize an access token for
 using the JIRA API.
 
@@ -95,17 +133,22 @@ errors are handled gracefully
   class ApplicationController < ActionController::Base
     protect_from_forgery
 
-    rescue_from JIRA::Client::UninitializedAccessTokenError do
+    rescue_from JIRA::OauthClient::UninitializedAccessTokenError do
       redirect_to new_jira_session_url
     end
 
     private
 
     def get_jira_client
+      
+      # add any extra configuration options for your instance of JIRA,
+      # e.g. :use_ssl, :ssl_verify_mode, :context_path, :site
       options = {
-        :private_key_file => "rsakey.pem"
+        :private_key_file => "rsakey.pem",
+        :consumer_key => 'test'
       }
-      @jira_client = JIRA::Client.new('test', '', options)
+
+      @jira_client = JIRA::Client.new(options)
 
       # Add AccessToken if authorised previously.
       if session[:jira_auth]
@@ -190,10 +233,11 @@ Here's the same example as a Sinatra application:
         :authorize_path     => "/plugins/servlet/oauth/authorize",
         :access_token_path  => "/plugins/servlet/oauth/access-token",
         :private_key_file   => "rsakey.pem",
-        :rest_base_path     => "/rest/api/2"
+        :rest_base_path     => "/rest/api/2",
+        :consumer_key       => "jira-ruby-example"
       }
 
-      @jira_client = JIRA::Client.new('jira-ruby-example', '', options)
+      @jira_client = JIRA::Client.new(options)
       @jira_client.consumer.http.set_debug_output($stderr)
 
       # Add AccessToken if authorised previously.

--- a/http-basic-example.rb
+++ b/http-basic-example.rb
@@ -1,0 +1,106 @@
+require 'rubygems'
+require 'pp'
+require 'jira'
+
+if ARGV.length == 0
+  # If not passed any command line arguments, prompt the
+  # user for the username and password.
+  puts "Enter the username: "
+  username = gets.strip
+
+  puts "Enter the password: "
+  password = gets.strip
+elsif ARGV.length == 2
+  username, password = ARGV[0], ARGV[1]
+else
+  # Script must be passed 0 or 2 arguments
+  raise "Usage: #{$0} [ username password ]"
+end
+
+options = {
+            :username => username,
+            :password => password,
+            :site     => 'http://localhost:8080/',
+            :context_path => '',
+            :auth_type => :basic,
+            :use_ssl => false
+          }
+
+client = JIRA::Client.new(options)
+
+# Show all projects
+projects = client.Project.all
+
+projects.each do |project|
+  puts "Project -> key: #{project.key}, name: #{project.name}"
+end
+
+# # Find a specific project by key
+# # ------------------------------
+# project = client.Project.find('SAMPLEPROJECT')
+# pp project
+# project.issues.each do |issue|
+#   puts "#{issue.id} - #{issue.fields['summary']}"
+# end
+#
+# # List all Issues
+# # ---------------
+# client.Issue.all.each do |issue|
+#   puts "#{issue.id} - #{issue.fields['summary']}"
+# end
+#
+# # Delete an issue
+# # ---------------
+# issue = client.Issue.find('SAMPLEPROJECT-2')
+# if issue.delete
+#   puts "Delete of issue SAMPLEPROJECT-2 sucessful"
+# else
+#   puts "Delete of issue SAMPLEPROJECT-2 failed"
+# end
+#
+# # Create an issue
+# # ---------------
+# issue = client.Issue.build
+# issue.save({"fields"=>{"summary"=>"blarg from in example.rb","project"=>{"id"=>"10001"},"issuetype"=>{"id"=>"3"}}})
+# issue.fetch
+# pp issue
+#
+# # Update an issue
+# # ---------------
+# issue = client.Issue.find("10002")
+# issue.save({"fields"=>{"summary"=>"EVEN MOOOOOOARRR NINJAAAA!"}})
+# pp issue
+#
+# # Find a user
+# # -----------
+# user = client.User.find('admin')
+# pp user
+#
+# # Get all issue types
+# # -------------------
+# issuetypes = client.Issuetype.all
+# pp issuetypes
+#
+# # Get a single issue type
+# # -----------------------
+# issuetype = client.Issuetype.find('5')
+# pp issuetype
+#
+# #  Get all comments for an issue
+# #  -----------------------------
+# issue.comments.each do |comment|
+#   pp comment
+# end
+#
+# # Build and Save a comment
+# # ------------------------
+# comment = issue.comments.build
+# comment.save!(:body => "New comment from example script")
+#
+# # Delete a comment from the collection
+# # ------------------------------------
+# issue.comments.last.delete
+#
+# # Update an existing comment
+# # --------------------------
+# issue.comments.first.save({"body" => "an updated comment frome example.rb"})

--- a/lib/jira.rb
+++ b/lib/jira.rb
@@ -22,6 +22,9 @@ require 'jira/resource/comment'
 require 'jira/resource/worklog'
 require 'jira/resource/issue'
 
+require 'jira/request_client'
+require 'jira/oauth_client'
+require 'jira/http_client'
 require 'jira/client'
 
 require 'jira/railtie' if defined?(Rails)

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -1,0 +1,41 @@
+require 'json'
+require 'net/https'
+
+module JIRA
+  class HttpClient < RequestClient
+
+    DEFAULT_OPTIONS = {
+      :username           => '',
+      :password           => ''
+    }
+
+    attr_reader :options
+
+    def initialize(options)
+      @options = DEFAULT_OPTIONS.merge(options)
+    end
+
+    def make_request(http_method, path, body='', headers)
+      request = Net::HTTP.const_get(http_method.capitalize).new(path, headers)
+      request.body = body unless body.nil?
+      request.basic_auth(@options[:username], @options[:password])
+      response = basic_auth_http_conn.request(request)
+      response
+    end
+
+    def basic_auth_http_conn
+      http_conn(uri)
+    end
+
+    def http_conn(uri)
+      http_conn = Net::HTTP.new(uri.host, uri.port)
+      http_conn.use_ssl = @options[:use_ssl]
+      http_conn.verify_mode = @options[:ssl_verify_mode]
+      http_conn
+    end
+
+    def uri
+      uri = URI.parse(@options[:site])
+    end
+  end
+end

--- a/lib/jira/oauth_client.rb
+++ b/lib/jira/oauth_client.rb
@@ -1,0 +1,84 @@
+require 'oauth'
+require 'json'
+require 'forwardable'
+
+module JIRA
+  class OauthClient < RequestClient
+
+    DEFAULT_OPTIONS = {
+      :signature_method   => 'RSA-SHA1',
+      :request_token_path => "/plugins/servlet/oauth/request-token",
+      :authorize_path     => "/plugins/servlet/oauth/authorize",
+      :access_token_path  => "/plugins/servlet/oauth/access-token",
+      :private_key_file   => "rsakey.pem",
+      :consumer_key       => nil,
+      :consumer_secret    => nil
+    }
+
+    # This exception is thrown when the client is used before the OAuth access token
+    # has been initialized.
+    class UninitializedAccessTokenError < StandardError
+      def message
+        "init_access_token must be called before using the client"
+      end
+    end
+
+    extend Forwardable
+
+    attr_accessor :consumer
+    attr_reader :options
+
+    def_instance_delegators :@consumer, :key, :secret, :get_request_token
+
+    def initialize(options)
+      @options = DEFAULT_OPTIONS.merge(options)
+      @consumer = init_oauth_consumer(@options)
+    end
+
+    def init_oauth_consumer(options)
+      @options[:request_token_path] = @options[:context_path] + @options[:request_token_path]
+      @options[:authorize_path] = @options[:context_path] + @options[:authorize_path]
+      @options[:access_token_path] = @options[:context_path] + @options[:access_token_path]
+      OAuth::Consumer.new(@options[:consumer_key],@options[:consumer_secret],@options)
+    end
+
+    # Returns the current request token if it is set, else it creates
+    # and sets a new token.
+    def request_token
+      @request_token ||= get_request_token
+    end
+
+    # Sets the request token from a given token and secret.
+    def set_request_token(token, secret)
+      @request_token = OAuth::RequestToken.new(@consumer, token, secret)
+    end
+
+    # Initialises and returns a new access token from the params hash
+    # returned by the OAuth transaction.
+    def init_access_token(params)
+      @access_token = request_token.get_access_token(params)
+    end
+
+    # Sets the access token from a preexisting token and secret.
+    def set_access_token(token, secret)
+      @access_token = OAuth::AccessToken.new(@consumer, token, secret)
+    end
+
+    # Returns the current access token. Raises an
+    # JIRA::Client::UninitializedAccessTokenError exception if it is not set.
+    def access_token
+      raise UninitializedAccessTokenError.new unless @access_token
+      @access_token
+    end
+
+    def make_request(http_method, path, body='', headers)
+      case http_method
+      when :delete, :get, :head
+        response = access_token.send http_method, path, headers
+      when :post, :put
+        response = access_token.send http_method, path, body, headers
+      end
+      response
+    end
+  end
+end

--- a/lib/jira/request_client.rb
+++ b/lib/jira/request_client.rb
@@ -1,0 +1,18 @@
+require 'oauth'
+require 'json'
+require 'net/https'
+
+module JIRA
+  class RequestClient
+
+    # Returns the response if the request was successful (HTTP::2xx) and
+    # raises a JIRA::HTTPError if it was not successful, with the response
+    # attached.
+
+    def request(*args)
+      response = make_request(*args)
+      raise HTTPError.new(response) unless response.kind_of?(Net::HTTPSuccess)
+      response
+    end
+  end
+end

--- a/spec/integration/attachment_spec.rb
+++ b/spec/integration/attachment_spec.rb
@@ -2,25 +2,22 @@ require 'spec_helper'
 
 describe JIRA::Resource::Attachment do
 
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
+    let(:key) { "10000" }
+
+    let(:expected_attributes) do
+      {
+        'self' => "http://localhost:2990/jira/rest/api/2/attachment/10000",
+        'size' => 15360,
+        'filename' => "ballmer.png"
+      }
+    end
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a singular GET endpoint"
+    it_should_behave_like "a resource with a DELETE endpoint"
   end
-
-  let(:key) { "10000" }
-
-  let(:expected_attributes) do
-    {
-      'self' => "http://localhost:2990/jira/rest/api/2/attachment/10000",
-      'size' => 15360,
-      'filename' => "ballmer.png"
-    }
-  end
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a singular GET endpoint"
-  it_should_behave_like "a resource with a DELETE endpoint"
-
 end

--- a/spec/integration/comment_spec.rb
+++ b/spec/integration/comment_spec.rb
@@ -2,54 +2,53 @@ require 'spec_helper'
 
 describe JIRA::Resource::Comment do
 
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
-  end
+    let(:key) { "10000" }
 
-  let(:key) { "10000" }
+    let(:target) { JIRA::Resource::Comment.new(client, :attrs => {'id' => '99999'}, :issue_id => '54321') }
 
-  let(:target) { JIRA::Resource::Comment.new(client, :attrs => {'id' => '99999'}, :issue_id => '54321') }
+    let(:expected_collection_length) { 2 }
 
-  let(:expected_collection_length) { 2 }
-
-  let(:belongs_to) {
-    JIRA::Resource::Issue.new(client, :attrs => {
-      'id' => '10002', 'fields' => {
-        'comment' => {'comments' => []}
-      }
-    })
-  }
-
-  let(:expected_attributes) do
-    {
-      'self' => "http://localhost:2990/jira/rest/api/2/issue/10002/comment/10000",
-      'id'   => key,
-      'body' => "This is a comment. Creative."
+    let(:belongs_to) {
+      JIRA::Resource::Issue.new(client, :attrs => {
+        'id' => '10002', 'fields' => {
+          'comment' => {'comments' => []}
+        }
+      })
     }
+
+    let(:expected_attributes) do
+      {
+        'self' => "http://localhost:2990/jira/rest/api/2/issue/10002/comment/10000",
+        'id'   => key,
+        'body' => "This is a comment. Creative."
+      }
+    end
+
+    let(:attributes_for_post) {
+      {"body" => "new comment"}
+    }
+    let(:expected_attributes_from_post) {
+      { "id" => "10001", "body" => "new comment"}
+    }
+
+    let(:attributes_for_put) {
+      {"body" => "new body"}
+    }
+    let(:expected_attributes_from_put) {
+      { "id" => "10000", "body" => "new body" }
+    }
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a collection GET endpoint"
+    it_should_behave_like "a resource with a singular GET endpoint"
+    it_should_behave_like "a resource with a DELETE endpoint"
+    it_should_behave_like "a resource with a POST endpoint"
+    it_should_behave_like "a resource with a PUT endpoint"
+
   end
-
-  let(:attributes_for_post) {
-    {"body" => "new comment"}
-  }
-  let(:expected_attributes_from_post) {
-    { "id" => "10001", "body" => "new comment"}
-  }
-
-  let(:attributes_for_put) {
-    {"body" => "new body"}
-  }
-  let(:expected_attributes_from_put) {
-    { "id" => "10000", "body" => "new body" }
-  }
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a collection GET endpoint"
-  it_should_behave_like "a resource with a singular GET endpoint"
-  it_should_behave_like "a resource with a DELETE endpoint"
-  it_should_behave_like "a resource with a POST endpoint"
-  it_should_behave_like "a resource with a PUT endpoint"
 
 end

--- a/spec/integration/component_spec.rb
+++ b/spec/integration/component_spec.rb
@@ -3,41 +3,40 @@ require 'spec_helper'
 describe JIRA::Resource::Component do
 
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
-  end
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
 
-  let(:key) { "10000" }
+    let(:key) { "10000" }
 
-  let(:expected_attributes) do
-    {
-      'self' => "http://localhost:2990/jira/rest/api/2/component/10000",
-      'id'   => key,
-      'name' => "Cheesecake"
+    let(:expected_attributes) do
+      {
+        'self' => "http://localhost:2990/jira/rest/api/2/component/10000",
+        'id'   => key,
+        'name' => "Cheesecake"
+      }
+    end
+
+    let(:attributes_for_post) {
+      {"name" => "Test component", "project" => "SAMPLEPROJECT" }
     }
+    let(:expected_attributes_from_post) {
+      { "id" => "10001", "name" => "Test component" }
+    }
+
+    let(:attributes_for_put) {
+      {"name" => "Jammy", "project" => "SAMPLEPROJECT" }
+    }
+    let(:expected_attributes_from_put) {
+      { "id" => "10000", "name" => "Jammy" }
+    }
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a singular GET endpoint"
+    it_should_behave_like "a resource with a DELETE endpoint"
+    it_should_behave_like "a resource with a POST endpoint"
+    it_should_behave_like "a resource with a PUT endpoint"
+    it_should_behave_like "a resource with a PUT endpoint that rejects invalid fields"
+
   end
-
-  let(:attributes_for_post) {
-    {"name" => "Test component", "project" => "SAMPLEPROJECT" }
-  }
-  let(:expected_attributes_from_post) {
-    { "id" => "10001", "name" => "Test component" }
-  }
-
-  let(:attributes_for_put) {
-    {"name" => "Jammy", "project" => "SAMPLEPROJECT" }
-  }
-  let(:expected_attributes_from_put) {
-    { "id" => "10000", "name" => "Jammy" }
-  }
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a singular GET endpoint"
-  it_should_behave_like "a resource with a DELETE endpoint"
-  it_should_behave_like "a resource with a POST endpoint"
-  it_should_behave_like "a resource with a PUT endpoint"
-  it_should_behave_like "a resource with a PUT endpoint that rejects invalid fields"
-
 end

--- a/spec/integration/issue_spec.rb
+++ b/spec/integration/issue_spec.rb
@@ -2,74 +2,77 @@ require 'spec_helper'
 
 describe JIRA::Resource::Issue do
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
-  end
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
 
-  let(:key) { "10002" }
 
-  let(:expected_attributes) do
-    {
-      'self'   => "http://localhost:2990/jira/rest/api/2/issue/10002",
-      'key'    => "SAMPLEPROJECT-1",
-      'expand' => "renderedFields,names,schema,transitions,editmeta,changelog"
-    }
-  end
+    let(:key) { "10002" }
 
-  let(:attributes_for_post) {
-    { 'foo' => 'bar' }
-  }
-  let(:expected_attributes_from_post) {
-    { "id" => "10005", "key" => "SAMPLEPROJECT-4" }
-  }
-
-  let(:attributes_for_put) {
-    { 'foo' => 'bar' }
-  }
-  let(:expected_attributes_from_put) {
-    { 'foo' => 'bar' }
-  }
-  let(:expected_collection_length) { 11 }
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a singular GET endpoint"
-  describe "GET all issues" do # JIRA::Resource::Issue.all uses the search endpoint
-    let(:expected_attributes) {
+    let(:expected_attributes) do
       {
-        "id"=>"10014",
-        "self"=>"http://localhost:2990/jira/rest/api/2/issue/10014",
-        "key"=>"SAMPLEPROJECT-13"
+        'self'   => "http://localhost:2990/jira/rest/api/2/issue/10002",
+        'key'    => "SAMPLEPROJECT-1",
+        'expand' => "renderedFields,names,schema,transitions,editmeta,changelog"
       }
+    end
+
+    let(:attributes_for_post) {
+      { 'foo' => 'bar' }
     }
-    before(:each) do
-      stub_request(:get, "http://localhost:2990/jira/rest/api/2/search").
-                  to_return(:status => 200, :body => get_mock_response('issue.json'))
+    let(:expected_attributes_from_post) {
+      { "id" => "10005", "key" => "SAMPLEPROJECT-4" }
+    }
+
+    let(:attributes_for_put) {
+      { 'foo' => 'bar' }
+    }
+    let(:expected_attributes_from_put) {
+      { 'foo' => 'bar' }
+    }
+    let(:expected_collection_length) { 11 }
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a singular GET endpoint"
+    describe "GET all issues" do # JIRA::Resource::Issue.all uses the search endpoint
+      let(:client) { client }
+      let(:site_url) { site_url }
+
+      let(:expected_attributes) {
+        {
+          "id"=>"10014",
+          "self"=>"http://localhost:2990/jira/rest/api/2/issue/10014",
+          "key"=>"SAMPLEPROJECT-13"
+        }
+      }
+      before(:each) do
+        stub_request(:get, site_url + "/jira/rest/api/2/search").
+                    to_return(:status => 200, :body => get_mock_response('issue.json'))
+      end
+      it_should_behave_like "a resource with a collection GET endpoint"
     end
-    it_should_behave_like "a resource with a collection GET endpoint"
+    it_should_behave_like "a resource with a DELETE endpoint"
+    it_should_behave_like "a resource with a POST endpoint"
+    it_should_behave_like "a resource with a PUT endpoint"
+    it_should_behave_like "a resource with a PUT endpoint that rejects invalid fields"
+
+    describe "errors" do
+      before(:each) do
+        stub_request(:get,
+                    site_url + "/jira/rest/api/2/issue/10002").
+                    to_return(:status => 200, :body => get_mock_response('issue/10002.json'))
+        stub_request(:put, site_url + "/jira/rest/api/2/issue/10002").
+                    with(:body => '{"missing":"fields and update"}').
+                    to_return(:status => 400, :body => get_mock_response('issue/10002.put.missing_field_update.json'))
+      end
+
+      it "fails to save when fields and update are missing" do
+        subject = client.Issue.build('id' => '10002')
+        subject.fetch
+        subject.save('missing' => 'fields and update').should be_false
+      end
+
+    end
+
   end
-  it_should_behave_like "a resource with a DELETE endpoint"
-  it_should_behave_like "a resource with a POST endpoint"
-  it_should_behave_like "a resource with a PUT endpoint"
-  it_should_behave_like "a resource with a PUT endpoint that rejects invalid fields"
-
-  describe "errors" do
-    before(:each) do
-      stub_request(:get,
-                  "http://localhost:2990/jira/rest/api/2/issue/10002").
-                  to_return(:status => 200, :body => get_mock_response('issue/10002.json'))
-      stub_request(:put, "http://localhost:2990/jira/rest/api/2/issue/10002").
-                  with(:body => '{"missing":"fields and update"}').
-                  to_return(:status => 400, :body => get_mock_response('issue/10002.put.missing_field_update.json'))
-    end
-
-    it "fails to save when fields and update are missing" do
-      subject = client.Issue.build('id' => '10002')
-      subject.fetch
-      subject.save('missing' => 'fields and update').should be_false
-    end
-
-  end
-
 end

--- a/spec/integration/issuetype_spec.rb
+++ b/spec/integration/issuetype_spec.rb
@@ -2,26 +2,25 @@ require 'spec_helper'
 
 describe JIRA::Resource::Issuetype do
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
+
+    let(:key) { "5" }
+
+    let(:expected_attributes) do
+      {
+        'self' => "http://localhost:2990/jira/rest/api/2/issuetype/5",
+        'id' => key,
+        'name' => 'Sub-task'
+      }
+    end
+
+    let(:expected_collection_length) { 5 }
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a collection GET endpoint"
+    it_should_behave_like "a resource with a singular GET endpoint"
+
   end
-
-  let(:key) { "5" }
-
-  let(:expected_attributes) do
-    {
-      'self' => "http://localhost:2990/jira/rest/api/2/issuetype/5",
-      'id' => key,
-      'name' => 'Sub-task'
-    }
-  end
-
-  let(:expected_collection_length) { 5 }
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a collection GET endpoint"
-  it_should_behave_like "a resource with a singular GET endpoint"
-
 end

--- a/spec/integration/priority_spec.rb
+++ b/spec/integration/priority_spec.rb
@@ -2,26 +2,26 @@ require 'spec_helper'
 
 describe JIRA::Resource::Priority do
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
+
+
+    let(:key) { "1" }
+
+    let(:expected_attributes) do
+      {
+        'self' => "http://localhost:2990/jira/rest/api/2/priority/1",
+        'id' => key,
+        'name' => 'Blocker'
+      }
+    end
+
+    let(:expected_collection_length) { 5 }
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a collection GET endpoint"
+    it_should_behave_like "a resource with a singular GET endpoint"
+
   end
-
-  let(:key) { "1" }
-
-  let(:expected_attributes) do
-    {
-      'self' => "http://localhost:2990/jira/rest/api/2/priority/1",
-      'id' => key,
-      'name' => 'Blocker'
-    }
-  end
-
-  let(:expected_collection_length) { 5 }
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a collection GET endpoint"
-  it_should_behave_like "a resource with a singular GET endpoint"
-
 end

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -2,55 +2,55 @@ require 'spec_helper'
 
 describe JIRA::Resource::Project do
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
-  end
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
 
-  let(:key) { "SAMPLEPROJECT" }
 
-  let(:expected_attributes) do
-    {
-      'self'   => "http://localhost:2990/jira/rest/api/2/project/SAMPLEPROJECT",
-      'key'    => key,
-      'name'   => "Sample Project for Developing RoR RESTful API"
-    }
-  end
+    let(:key) { "SAMPLEPROJECT" }
 
-  let(:expected_collection_length) { 1 }
+    let(:expected_attributes) do
+      {
+        'self'   => "http://localhost:2990/jira/rest/api/2/project/SAMPLEPROJECT",
+        'key'    => key,
+        'name'   => "Sample Project for Developing RoR RESTful API"
+      }
+    end
 
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a collection GET endpoint"
-  it_should_behave_like "a resource with a singular GET endpoint"
+    let(:expected_collection_length) { 1 }
 
-  describe "issues" do
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a collection GET endpoint"
+    it_should_behave_like "a resource with a singular GET endpoint"
 
-    it "returns all the issues" do
-      stub_request(:get, "http://localhost:2990/jira/rest/api/2/search?jql=project='SAMPLEPROJECT'").
-        to_return(:status => 200, :body => get_mock_response('project/SAMPLEPROJECT.issues.json'))
-      subject = client.Project.build('key' => key)
-      issues = subject.issues
-      issues.length.should == 11
-      issues.each do |issue|
-        issue.class.should == JIRA::Resource::Issue
-        issue.expanded?.should be_false
+    describe "issues" do
+
+      it "returns all the issues" do
+        stub_request(:get, site_url + "/jira/rest/api/2/search?jql=project='SAMPLEPROJECT'").
+          to_return(:status => 200, :body => get_mock_response('project/SAMPLEPROJECT.issues.json'))
+        subject = client.Project.build('key' => key)
+        issues = subject.issues
+        issues.length.should == 11
+        issues.each do |issue|
+          issue.class.should == JIRA::Resource::Issue
+          issue.expanded?.should be_false
+        end
+
       end
 
     end
 
-  end
+    it "returns a collection of components" do
 
-  it "returns a collection of components" do
+      stub_request(:get, site_url + described_class.singular_path(client, key)).
+        to_return(:status => 200, :body => get_mock_response('project/SAMPLEPROJECT.json'))
 
-    stub_request(:get, 'http://localhost:2990' + described_class.singular_path(client, key)).
-      to_return(:status => 200, :body => get_mock_response('project/SAMPLEPROJECT.json'))
+      subject = client.Project.find(key)
+      subject.components.length.should == 2
+      subject.components.each do |component|
+        component.class.should == JIRA::Resource::Component
+      end
 
-    subject = client.Project.find(key)
-    subject.components.length.should == 2
-    subject.components.each do |component|
-      component.class.should == JIRA::Resource::Component
     end
-
   end
 end

--- a/spec/integration/status_spec.rb
+++ b/spec/integration/status_spec.rb
@@ -2,26 +2,26 @@ require 'spec_helper'
 
 describe JIRA::Resource::Status do
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
+
+
+    let(:key) { "1" }
+
+    let(:expected_attributes) do
+      {
+        'self' => "http://localhost:2990/jira/rest/api/2/status/1",
+        'id' => key,
+        'name' => 'Open'
+      }
+    end
+
+    let(:expected_collection_length) { 5 }
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a collection GET endpoint"
+    it_should_behave_like "a resource with a singular GET endpoint"
+
   end
-
-  let(:key) { "1" }
-
-  let(:expected_attributes) do
-    {
-      'self' => "http://localhost:2990/jira/rest/api/2/status/1",
-      'id' => key,
-      'name' => 'Open'
-    }
-  end
-
-  let(:expected_collection_length) { 5 }
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a collection GET endpoint"
-  it_should_behave_like "a resource with a singular GET endpoint"
-
 end

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -3,23 +3,23 @@ require 'spec_helper'
 describe JIRA::Resource::User do
 
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
+
+
+    let(:key) { "admin" }
+
+    let(:expected_attributes) do
+      {
+        'self' => "http://localhost:2990/jira/rest/api/2/user?username=admin",
+        'name' => key,
+        'emailAddress' => 'admin@example.com'
+      }
+    end
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a singular GET endpoint"
+
   end
-
-  let(:key) { "admin" }
-
-  let(:expected_attributes) do
-    {
-      'self' => "http://localhost:2990/jira/rest/api/2/user?username=admin",
-      'name' => key,
-      'emailAddress' => 'admin@example.com'
-    }
-  end
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a singular GET endpoint"
-
 end

--- a/spec/integration/version_spec.rb
+++ b/spec/integration/version_spec.rb
@@ -3,41 +3,41 @@ require 'spec_helper'
 describe JIRA::Resource::Version do
 
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
-  end
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
 
-  let(:key) { "10000" }
 
-  let(:expected_attributes) do
-    {
-      'self' => "http://localhost:2990/jira/rest/api/2/version/10000",
-      'id'   => key,
-      'description' => "Initial version"
+    let(:key) { "10000" }
+
+    let(:expected_attributes) do
+      {
+        'self' => "http://localhost:2990/jira/rest/api/2/version/10000",
+        'id'   => key,
+        'description' => "Initial version"
+      }
+    end
+
+    let(:attributes_for_post) {
+      {"name" => "2.0", "project" => "SAMPLEPROJECT" }
     }
+    let(:expected_attributes_from_post) {
+      { "id" => "10001", "name" => "2.0" }
+    }
+
+    let(:attributes_for_put) {
+      {"name" => "2.0.0" }
+    }
+    let(:expected_attributes_from_put) {
+      { "id" => "10000", "name" => "2.0.0" }
+    }
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a singular GET endpoint"
+    it_should_behave_like "a resource with a DELETE endpoint"
+    it_should_behave_like "a resource with a POST endpoint"
+    it_should_behave_like "a resource with a PUT endpoint"
+    it_should_behave_like "a resource with a PUT endpoint that rejects invalid fields"
+
   end
-
-  let(:attributes_for_post) {
-    {"name" => "2.0", "project" => "SAMPLEPROJECT" }
-  }
-  let(:expected_attributes_from_post) {
-    { "id" => "10001", "name" => "2.0" }
-  }
-
-  let(:attributes_for_put) {
-    {"name" => "2.0.0" }
-  }
-  let(:expected_attributes_from_put) {
-    { "id" => "10000", "name" => "2.0.0" }
-  }
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a singular GET endpoint"
-  it_should_behave_like "a resource with a DELETE endpoint"
-  it_should_behave_like "a resource with a POST endpoint"
-  it_should_behave_like "a resource with a PUT endpoint"
-  it_should_behave_like "a resource with a PUT endpoint that rejects invalid fields"
-
 end

--- a/spec/integration/worklog_spec.rb
+++ b/spec/integration/worklog_spec.rb
@@ -3,53 +3,53 @@ require 'spec_helper'
 describe JIRA::Resource::Worklog do
 
 
-  let(:client) do
-    client = JIRA::Client.new('foo', 'bar')
-    client.set_access_token('abc', '123')
-    client
-  end
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
 
-  let(:key) { "10000" }
 
-  let(:target) { JIRA::Resource::Worklog.new(client, :attrs => {'id' => '99999'}, :issue_id => '54321') }
+    let(:key) { "10000" }
 
-  let(:expected_collection_length) { 3 }
+    let(:target) { JIRA::Resource::Worklog.new(client, :attrs => {'id' => '99999'}, :issue_id => '54321') }
 
-  let(:belongs_to) {
-    JIRA::Resource::Issue.new(client, :attrs => {
-      'id' => '10002', 'fields' => {
-        'comment' => {'comments' => []}
-      }
-    })
-  }
+    let(:expected_collection_length) { 3 }
 
-  let(:expected_attributes) do
-    {
-      'self' => "http://localhost:2990/jira/rest/api/2/issue/10002/worklog/10000",
-      'id'   => key,
-      'comment' => "Some epic work."
+    let(:belongs_to) {
+      JIRA::Resource::Issue.new(client, :attrs => {
+        'id' => '10002', 'fields' => {
+          'comment' => {'comments' => []}
+        }
+      })
     }
+
+    let(:expected_attributes) do
+      {
+        'self' => "http://localhost:2990/jira/rest/api/2/issue/10002/worklog/10000",
+        'id'   => key,
+        'comment' => "Some epic work."
+      }
+    end
+
+    let(:attributes_for_post) {
+      {"timeSpent" => "2d"}
+    }
+    let(:expected_attributes_from_post) {
+      { "id" => "10001", "timeSpent" => "2d"}
+    }
+
+    let(:attributes_for_put) {
+      {"timeSpent" => "2d"}
+    }
+    let(:expected_attributes_from_put) {
+      { "id" => "10001", "timeSpent" => "4d"}
+    }
+
+    it_should_behave_like "a resource"
+    it_should_behave_like "a resource with a collection GET endpoint"
+    it_should_behave_like "a resource with a singular GET endpoint"
+    it_should_behave_like "a resource with a DELETE endpoint"
+    it_should_behave_like "a resource with a POST endpoint"
+    it_should_behave_like "a resource with a PUT endpoint"
+
   end
-
-  let(:attributes_for_post) {
-    {"timeSpent" => "2d"}
-  }
-  let(:expected_attributes_from_post) {
-    { "id" => "10001", "timeSpent" => "2d"}
-  }
-
-  let(:attributes_for_put) {
-    {"timeSpent" => "2d"}
-  }
-  let(:expected_attributes_from_put) {
-    { "id" => "10001", "timeSpent" => "4d"}
-  }
-
-  it_should_behave_like "a resource"
-  it_should_behave_like "a resource with a collection GET endpoint"
-  it_should_behave_like "a resource with a singular GET endpoint"
-  it_should_behave_like "a resource with a DELETE endpoint"
-  it_should_behave_like "a resource with a POST endpoint"
-  it_should_behave_like "a resource with a PUT endpoint"
-
 end

--- a/spec/jira/client_spec.rb
+++ b/spec/jira/client_spec.rb
@@ -2,157 +2,187 @@ require 'spec_helper'
 
 describe JIRA::Client do
 
-  subject {JIRA::Client.new('foo','bar')}
+  let(:oauth_client) do
+    JIRA::Client.new({ :consumer_key => 'foo', :consumer_secret => 'bar' })
+  end
+
+  let(:basic_client) do
+    JIRA::Client.new({ :username => 'foo', :password => 'bar', :auth_type => :basic })
+  end
+
+  let(:clients) { [oauth_client, basic_client] }
 
   let(:response) do
     response = mock("response")
     response.stub(:kind_of?).with(Net::HTTPSuccess).and_return(true)
     response
   end
+
+  let(:headers) { {'Accept' => 'application/json'} }
+  let(:content_type_header) { {'Content-Type' => 'application/json'} }
+  let(:merged_headers) { headers.merge(content_type_header) }
   
   it "creates an instance" do
-    subject.class.should == JIRA::Client
-  end
-
-  it "sets consumer key" do
-    subject.key.should == 'foo'
-  end
-
-  it "sets consumer secret" do
-    subject.secret.should == 'bar'
-  end
-
-  it "sets the non path default options" do
-    options = [:site, :signature_method, :private_key_file]
-    options.each do |key|
-      subject.options[key].should == JIRA::Client::DEFAULT_OPTIONS[key]
-    end
+    clients.each {|client| client.class.should == JIRA::Client }
   end
 
   it "allows the overriding of some options" do
-    # Check it overrides a given option ...
-    client = JIRA::Client.new('foo', 'bar', :site => 'http://foo.com/')
+    client = JIRA::Client.new({:consumer_key => 'foo', :consumer_secret => 'bar', :site => 'http://foo.com/'})
     client.options[:site].should == 'http://foo.com/'
     JIRA::Client::DEFAULT_OPTIONS[:site].should_not == 'http://foo.com/'
   end
 
-  it "prepends the context path to all authorization and rest paths" do
-    options = [:request_token_path, :authorize_path, :access_token_path, :rest_base_path]
+  it "prepends the context path to the rest base path" do
+    options = [:rest_base_path]
     defaults = JIRA::Client::DEFAULT_OPTIONS
     options.each do |key|
-      subject.options[key].should == defaults[:context_path] + defaults[key]
+      clients.each { |client| client.options[key].should == defaults[:context_path] + defaults[key] }
     end
   end
 
   # To avoid having to validate options after initialisation, e.g. setting
   # client.options[:invalid] = 'foo'
   it "freezes the options" do
-    subject.options.should be_frozen
+    clients.each { |client| client.options.should be_frozen }
   end
 
-  it "creates a Oauth::Consumer on initialize" do
-    subject.consumer.class.should == OAuth::Consumer
-    subject.consumer.key.should == subject.key
-    subject.consumer.secret.should == subject.secret
+  it "merges headers" do
+    clients.each { |client| client.send(:merge_default_headers, {}).should == {'Accept' => 'application/json'} }
   end
 
-  it "returns an OAuth request_token" do
-    # Cannot just check for method delegation as http connection will be attempted
-    request_token = OAuth::RequestToken.new(subject.consumer)
-    subject.consumer.stub(:get_request_token => request_token)
-    subject.get_request_token.should == request_token
-  end
-
-  it "is possible to set the request token" do
-    token = mock()
-    OAuth::RequestToken.should_receive(:new).with(subject.consumer, 'foo', 'bar').and_return(token)
-
-    request_token = subject.set_request_token('foo', 'bar')
-
-    request_token.should         == token
-    subject.request_token.should == token
-  end
-
-  describe "access token" do
-
-    it "initializes the access token" do
-      request_token = OAuth::RequestToken.new(subject.consumer)
-      subject.consumer.stub(:get_request_token => request_token)
-      mock_access_token = mock()
-      request_token.should_receive(:get_access_token).with(:oauth_verifier => 'abc123').and_return(mock_access_token)
-      subject.init_access_token(:oauth_verifier => 'abc123')
-      subject.access_token.should == mock_access_token
+  describe "creates instances of request clients" do
+    specify "that are of the correct class" do
+      oauth_client.request_client.class.should == JIRA::OauthClient
+      basic_client.request_client.class.should == JIRA::HttpClient
     end
 
-    it "raises an exception when accessing without initialisation" do
-      lambda do
-        subject.access_token
-      end.should raise_exception(JIRA::Client::UninitializedAccessTokenError, "init_access_token must be called before using the client")
+    specify "which have a corresponding auth type option" do
+      oauth_client.options[:auth_type].should == :oauth
+      basic_client.options[:auth_type].should == :basic
     end
 
-    it "is possible to set the access token" do
-      token = mock()
-      OAuth::AccessToken.should_receive(:new).with(subject.consumer, 'foo', 'bar').and_return(token)
+    describe "like oauth" do
 
-      access_token = subject.set_access_token('foo', 'bar')
+      it "allows setting an access token" do
+        token = mock()
+        OAuth::AccessToken.should_receive(:new).with(oauth_client.consumer, 'foo', 'bar').and_return(token)
+        access_token = oauth_client.set_access_token('foo', 'bar')
 
-      access_token.should         == token
-      subject.access_token.should == token
+        access_token.should         == token
+        oauth_client.access_token.should == token
+      end
+
+      it "allows initializing the access token" do
+        request_token = OAuth::RequestToken.new(oauth_client.consumer)
+        oauth_client.consumer.stub(:get_request_token => request_token)
+        mock_access_token = mock()
+        request_token.should_receive(:get_access_token).with(:oauth_verifier => 'abc123').and_return(mock_access_token)
+        oauth_client.init_access_token(:oauth_verifier => 'abc123')
+        oauth_client.access_token.should == mock_access_token
+      end
+
+      specify "that has specific default options" do
+        options = [:signature_method, :private_key_file]
+        options.each do |key|
+          oauth_client.options[key].should == JIRA::Client::DEFAULT_OPTIONS[key]
+        end
+      end
     end
 
+    describe "like basic http" do
+      it "sets the username and password" do
+        basic_client.options[:username].should == 'foo'
+        basic_client.options[:password].should == 'bar'
+      end
+    end
   end
 
-  describe "http" do
+  describe "has http methods" do
+    before do
+      oauth_client.set_access_token("foo", "bar")
+    end
 
-    it "responds to the http methods" do
-      mock_access_token = mock()
-      subject.stub(:access_token => mock_access_token)
+    specify "that merge default headers" do
+      # stubbed response for generic client request method
+      oauth_client.should_receive(:request).exactly(5).times.and_return(response)
+      basic_client.should_receive(:request).exactly(5).times.and_return(response)
+
+      # response for merging headers for http methods with no body
+      oauth_client.should_receive(:merge_default_headers).exactly(3).times.with({})
+      basic_client.should_receive(:merge_default_headers).exactly(3).times.with({})
+
+      # response for merging headers for http methods with body
+      oauth_client.should_receive(:merge_default_headers).exactly(2).times.with(content_type_header)
+      basic_client.should_receive(:merge_default_headers).exactly(2).times.with(content_type_header)
+
       [:delete, :get, :head].each do |method|
-        mock_access_token.should_receive(:request).with(method, '/path', {'Accept' => 'application/json'}).and_return(response)
-        subject.send(method, '/path')
+        oauth_client.send(method, '/path', {})
+        basic_client.send(method, '/path', {})
       end
+
       [:post, :put].each do |method|
-        mock_access_token.should_receive(:request).with(method,
-                                                        '/path', '',
-                                                        {'Accept' => 'application/json', 'Content-Type' => 'application/json'}).and_return(response)
-        subject.send(method, '/path')
+        oauth_client.send(method, '/path', '', content_type_header)
+        basic_client.send(method, '/path', '', content_type_header)
       end
     end
 
-    it "performs a request" do
-      access_token = mock()
-      access_token.should_receive(:request).with(:get, '/foo').and_return(response)
-      subject.stub(:access_token => access_token)
-      subject.request(:get, '/foo')
+    specify "that call the generic request method" do
+      [:delete, :get, :head].each do |method|
+        oauth_client.should_receive(:request).with(method, '/path', nil, headers).and_return(response)
+        basic_client.should_receive(:request).with(method, '/path', nil, headers).and_return(response)
+        oauth_client.send(method, '/path', {})
+        basic_client.send(method, '/path', {})
+      end
+
+      [:post, :put].each do |method|
+        oauth_client.should_receive(:request).with(method, '/path', '', merged_headers)
+        basic_client.should_receive(:request).with(method, '/path', '', merged_headers)
+        oauth_client.send(method, '/path', '', {})
+        basic_client.send(method, '/path', '', {})
+      end
     end
 
-    it "raises an exception for non success responses" do
-      response = mock()
-      response.stub(:kind_of?).with(Net::HTTPSuccess).and_return(false)
-      access_token = mock()
-      access_token.should_receive(:request).with(:get, '/foo').and_return(response)
-      subject.stub(:access_token => access_token)
-      
-      lambda do
-        subject.request(:get, '/foo')
-      end.should raise_exception(JIRA::HTTPError)
+    describe "that call a oauth client" do
+      specify "which makes a request" do
+        [:delete, :get, :head].each do |method|
+          oauth_client.request_client.should_receive(:make_request).with(method, '/path', nil, headers).and_return(response)
+          oauth_client.send(method, '/path', {})
+        end
+        [:post, :put].each do |method|
+          oauth_client.request_client.should_receive(:make_request).with(method, '/path', '', merged_headers).and_return(response)
+          oauth_client.send(method, '/path', '', {})
+        end
+      end
     end
-
+    
+    describe "that call a http client" do
+      it "which makes a request" do
+        [:delete, :get, :head].each do |method|
+          basic_client.request_client.should_receive(:make_request).with(method, '/path', nil, headers).and_return(response)
+          basic_client.send(method, '/path', headers)
+        end
+        [:post, :put].each do |method|
+          basic_client.request_client.should_receive(:make_request).with(method, '/path', '', merged_headers).and_return(response)
+          basic_client.send(method, '/path', '', headers)
+        end
+      end
+    end
   end
-
+  
   describe "Resource Factories" do
-
     it "gets all projects" do
-      JIRA::Resource::Project.should_receive(:all).with(subject).and_return([])
-      subject.Project.all.should == []
+      JIRA::Resource::Project.should_receive(:all).with(oauth_client).and_return([])
+      JIRA::Resource::Project.should_receive(:all).with(basic_client).and_return([])
+      oauth_client.Project.all.should == []
+      basic_client.Project.all.should == []
     end
 
     it "finds a single project" do
       find_result = mock()
-      JIRA::Resource::Project.should_receive(:find).with(subject, '123').and_return(find_result)
-      subject.Project.find('123').should == find_result
+      JIRA::Resource::Project.should_receive(:find).with(oauth_client, '123').and_return(find_result)
+      JIRA::Resource::Project.should_receive(:find).with(basic_client, '123').and_return(find_result)
+      oauth_client.Project.find('123').should == find_result
+      basic_client.Project.find('123').should == find_result
     end
-
   end
-
 end

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe JIRA::HttpClient do
+
+  let(:basic_client) do
+    options = JIRA::Client::DEFAULT_OPTIONS.merge(JIRA::HttpClient::DEFAULT_OPTIONS)
+    JIRA::HttpClient.new(options)
+  end
+
+  let(:response) do
+    response = mock("response")
+    response.stub(:kind_of?).with(Net::HTTPSuccess).and_return(true)
+    response
+  end
+
+  it "creates an instance of Net:HTTP for a basic auth client" do
+    basic_client.basic_auth_http_conn.class.should == Net::HTTP
+  end
+
+  it "responds to the http methods" do
+    body = ''
+    headers = mock()
+    basic_auth_http_conn = mock()
+    request = mock()
+    basic_client.stub(:basic_auth_http_conn => basic_auth_http_conn)
+    request.should_receive(:basic_auth)
+           .with(basic_client.options[:username], basic_client.options[:password])
+           .exactly(5).times.and_return(request)
+    basic_auth_http_conn.should_receive(:request).exactly(5).times.with(request).and_return(response)
+    [:delete, :get, :head].each do |method|
+      Net::HTTP.const_get(method.capitalize).should_receive(:new).with('/path', headers).and_return(request)
+      basic_client.make_request(method, '/path', nil, headers).should == response
+    end
+    [:post, :put].each do |method|
+      Net::HTTP.const_get(method.capitalize).should_receive(:new).with('/path', headers).and_return(request)
+      request.should_receive(:body=).with(body).and_return(request)
+      basic_client.make_request(method, '/path', body, headers).should == response
+    end
+  end
+
+  it "performs a basic http client request" do
+    body = nil
+    headers = mock()
+    basic_auth_http_conn = mock()
+    http_request = mock()
+    Net::HTTP::Get.should_receive(:new).with('/foo', headers).and_return(http_request)
+
+    basic_auth_http_conn.should_receive(:request).with(http_request).and_return(response)
+    http_request.should_receive(:basic_auth).with(basic_client.options[:username], basic_client.options[:password]).and_return(http_request)
+    basic_client.stub(:basic_auth_http_conn => basic_auth_http_conn)
+    basic_client.make_request(:get, '/foo', body, headers)
+  end
+
+  it "returns a URI" do
+    uri = URI.parse(basic_client.options[:site])
+    basic_client.uri.should == uri
+  end
+
+  it "sets up a http connection with options" do
+    http_conn = mock()
+    uri = mock()
+    host = mock()
+    port = mock()
+    uri.should_receive(:host).and_return(host)
+    uri.should_receive(:port).and_return(port)
+    Net::HTTP.should_receive(:new).with(host, port).and_return(http_conn)
+    http_conn.should_receive(:use_ssl=).with(basic_client.options[:use_ssl]).and_return(http_conn)
+    http_conn.should_receive(:verify_mode=).with(basic_client.options[:ssl_verify_mode]).and_return(http_conn)
+    basic_client.http_conn(uri).should == http_conn
+  end
+
+  it "returns a http connection" do
+    http_conn = mock()
+    uri = mock()
+    basic_client.should_receive(:uri).and_return(uri)
+    basic_client.should_receive(:http_conn).and_return(http_conn)
+    basic_client.basic_auth_http_conn.should == http_conn
+  end
+end

--- a/spec/jira/oauth_client_spec.rb
+++ b/spec/jira/oauth_client_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+describe JIRA::OauthClient do
+
+  let(:oauth_client) do
+    options = { :consumer_key => 'foo', :consumer_secret => 'bar' }
+    options = JIRA::Client::DEFAULT_OPTIONS.merge(options)
+    JIRA::OauthClient.new(options)
+  end
+
+  let(:response) do
+    response = mock("response")
+    response.stub(:kind_of?).with(Net::HTTPSuccess).and_return(true)
+    response
+  end
+  
+  describe "authenticating with oauth" do
+    it "prepends the context path to all authorization and rest paths" do
+      options = [:request_token_path, :authorize_path, :access_token_path]
+      defaults = JIRA::Client::DEFAULT_OPTIONS.merge(JIRA::OauthClient::DEFAULT_OPTIONS)
+      options.each do |key|
+        oauth_client.options[key].should == defaults[:context_path] + defaults[key]
+      end
+    end
+
+    it "creates a Oauth::Consumer on initialize" do
+      oauth_client.consumer.class.should == OAuth::Consumer
+      oauth_client.consumer.key.should == oauth_client.key
+      oauth_client.consumer.secret.should == oauth_client.secret
+    end
+
+    it "returns an OAuth request_token" do
+      # Cannot just check for method delegation as http connection will be attempted
+      request_token = OAuth::RequestToken.new(oauth_client.consumer)
+      oauth_client.consumer.stub(:get_request_token => request_token)
+      oauth_client.get_request_token.should == request_token
+    end
+
+    it "allows setting the request token" do
+      token = mock()
+      OAuth::RequestToken.should_receive(:new).with(oauth_client.consumer, 'foo', 'bar').and_return(token)
+
+      request_token = oauth_client.set_request_token('foo', 'bar')
+
+      request_token.should == token
+      oauth_client.request_token.should == token
+    end
+
+    it "allows setting the consumer key" do
+      oauth_client.key.should == 'foo'
+    end
+
+    it "allows setting the consumer secret" do
+      oauth_client.secret.should == 'bar'
+    end
+
+    describe "the access token" do
+
+      it "initializes" do
+        request_token = OAuth::RequestToken.new(oauth_client.consumer)
+        oauth_client.consumer.stub(:get_request_token => request_token)
+        mock_access_token = mock()
+        request_token.should_receive(:get_access_token).with(:oauth_verifier => 'abc123').and_return(mock_access_token)
+        oauth_client.init_access_token(:oauth_verifier => 'abc123')
+        oauth_client.access_token.should == mock_access_token
+      end
+
+      it "raises an exception when accessing without initialisation" do
+        expect {
+          oauth_client.access_token
+        }.to raise_exception(JIRA::OauthClient::UninitializedAccessTokenError, 
+                             "init_access_token must be called before using the client")
+      end
+
+      it "allows setting the access token" do
+        token = mock()
+        OAuth::AccessToken.should_receive(:new).with(oauth_client.consumer, 'foo', 'bar').and_return(token)
+
+        access_token = oauth_client.set_access_token('foo', 'bar')
+
+        access_token.should         == token
+        oauth_client.access_token.should == token
+      end
+    end
+
+    describe "http" do
+      it "responds to the http methods" do
+        headers = mock()
+        mock_access_token = mock()
+        oauth_client.stub(:access_token => mock_access_token)
+        [:delete, :get, :head].each do |method|
+          mock_access_token.should_receive(method).with('/path', headers).and_return(response)
+          oauth_client.make_request(method, '/path', '', headers)
+        end
+        [:post, :put].each do |method|
+          mock_access_token.should_receive(method).with('/path', '', headers).and_return(response)
+          oauth_client.make_request(method, '/path', '', headers)
+        end
+      end
+
+      it "performs a request" do
+        body = nil
+        headers = mock()
+        access_token = mock()
+        access_token.should_receive(:send).with(:get, '/foo', headers).and_return(response)
+        oauth_client.stub(:access_token => access_token)
+        oauth_client.request(:get, '/foo', body, headers)
+      end
+    end
+  end
+end

--- a/spec/jira/request_client_spec.rb
+++ b/spec/jira/request_client_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe JIRA::RequestClient do
+
+  it "raises an exception for non success responses" do
+    response = mock()
+    response.stub(:kind_of?).with(Net::HTTPSuccess).and_return(false)
+    rc = JIRA::RequestClient.new
+    rc.should_receive(:make_request).with(:get, '/foo', '', {}).and_return(response)
+    expect {
+      rc.request(:get, '/foo', '', {})
+    }.to raise_exception(JIRA::HTTPError)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ Dir["./spec/support/**/*.rb"].each {|f| require f}
 require 'jira'
 
 RSpec.configure do |config|
-
+  config.extend ClientsHelper
 end
 
 

--- a/spec/support/clients_helper.rb
+++ b/spec/support/clients_helper.rb
@@ -1,0 +1,16 @@
+module ClientsHelper
+  def with_each_client
+    clients = {}
+
+    oauth_client = JIRA::Client.new({ :consumer_key => 'foo', :consumer_secret => 'bar' })
+    oauth_client.set_access_token('abc', '123')
+    clients["http://localhost:2990"] = oauth_client
+
+    basic_client = JIRA::Client.new({ :username => 'foo', :password => 'bar', :auth_type => :basic, :use_ssl => false })
+    clients["http://foo:bar@localhost:2990"] = basic_client
+
+    clients.each do |site_url, client|
+      yield site_url, client
+    end
+  end
+end

--- a/spec/support/shared_examples/integration.rb
+++ b/spec/support/shared_examples/integration.rb
@@ -55,7 +55,7 @@ shared_examples "a resource" do
     else
       subject = client.send(class_basename).build(described_class.key_attribute.to_s => '99999')
     end
-    stub_request(:put, 'http://localhost:2990' + subject.url).
+    stub_request(:put, site_url + subject.url).
                 to_return(:status => 405, :body => "<html><body>Some HTML</body></html>")
     subject.save('foo' => 'bar').should be_false
     lambda do
@@ -68,7 +68,7 @@ end
 shared_examples "a resource with a collection GET endpoint" do
 
   it "should get the collection" do
-    stub_request(:get, "http://localhost:2990" + described_class.collection_path(client)).
+    stub_request(:get, site_url + described_class.collection_path(client)).
                  to_return(:status => 200, :body => get_mock_from_path(:get))
     collection = build_receiver.all
     collection.length.should == expected_collection_length
@@ -84,7 +84,7 @@ shared_examples "a resource with a singular GET endpoint" do
   it "GETs a single resource" do
     # E.g., for JIRA::Resource::Project, we need to call
     # client.Project.find()
-    stub_request(:get, "http://localhost:2990" + described_class.singular_path(client, key, prefix)).
+    stub_request(:get, site_url + described_class.singular_path(client, key, prefix)).
                 to_return(:status => 200, :body => get_mock_from_path(:get, :key => key))
     subject = client.send(class_basename).find(key, options)
 
@@ -94,7 +94,7 @@ shared_examples "a resource with a singular GET endpoint" do
   it "builds and fetches a single resource" do
     # E.g., for JIRA::Resource::Project, we need to call
     # client.Project.build('key' => 'ABC123')
-    stub_request(:get, "http://localhost:2990" + described_class.singular_path(client, key, prefix)).
+    stub_request(:get, site_url + described_class.singular_path(client, key, prefix)).
                 to_return(:status => 200, :body => get_mock_from_path(:get, :key => key))
 
     subject = build_receiver.build(described_class.key_attribute.to_s => key)
@@ -104,7 +104,7 @@ shared_examples "a resource with a singular GET endpoint" do
   end
 
   it "handles a 404" do
-    stub_request(:get, "http://localhost:2990" + described_class.singular_path(client, '99999', prefix)).
+    stub_request(:get, site_url + described_class.singular_path(client, '99999', prefix)).
                 to_return(:status => 404, :body => '{"errorMessages":["'+class_basename+' Does Not Exist"],"errors": {}}')
     lambda do
       client.send(class_basename).find('99999', options)
@@ -116,7 +116,7 @@ shared_examples "a resource with a DELETE endpoint" do
   it "deletes a resource" do
     # E.g., for JIRA::Resource::Project, we need to call
     # client.Project.delete()
-    stub_request(:delete, "http://localhost:2990" + described_class.singular_path(client, key, prefix)).
+    stub_request(:delete, site_url + described_class.singular_path(client, key, prefix)).
                 to_return(:status => 204, :body => nil)
 
     subject = build_receiver.build(described_class.key_attribute.to_s => key)
@@ -127,7 +127,7 @@ end
 shared_examples "a resource with a POST endpoint" do
 
   it "saves a new resource" do
-    stub_request(:post, "http://localhost:2990" + described_class.collection_path(client, prefix)).
+    stub_request(:post, site_url + described_class.collection_path(client, prefix)).
                 to_return(:status => 201, :body => get_mock_from_path(:post))
     subject = build_receiver.build
     subject.save(attributes_for_post).should be_true
@@ -141,9 +141,9 @@ end
 shared_examples "a resource with a PUT endpoint" do
 
   it "saves an existing component" do
-    stub_request(:get, "http://localhost:2990" + described_class.singular_path(client, key, prefix)).
+    stub_request(:get, site_url + described_class.singular_path(client, key, prefix)).
                 to_return(:status => 200, :body => get_mock_from_path(:get, :key =>key))
-    stub_request(:put, "http://localhost:2990" + described_class.singular_path(client, key, prefix)).
+    stub_request(:put, site_url + described_class.singular_path(client, key, prefix)).
                   to_return(:status => 200, :body => get_mock_from_path(:put, :key => key, :value_if_not_found => nil))
     subject = build_receiver.build(described_class.key_attribute.to_s => key)
     subject.fetch
@@ -158,9 +158,9 @@ end
 shared_examples 'a resource with a PUT endpoint that rejects invalid fields' do
 
   it "fails to save with an invalid field" do
-    stub_request(:get, "http://localhost:2990" + described_class.singular_path(client, key)).
+    stub_request(:get, site_url + described_class.singular_path(client, key)).
                 to_return(:status => 200, :body => get_mock_from_path(:get, :key => key))
-    stub_request(:put, "http://localhost:2990" + described_class.singular_path(client, key)).
+    stub_request(:put, site_url + described_class.singular_path(client, key)).
                 to_return(:status => 400, :body => get_mock_from_path(:put, :key => key, :suffix => "invalid"))
     subject = client.send(class_basename).build(described_class.key_attribute.to_s => key)
     subject.fetch


### PR DESCRIPTION
Quite a large set of changes:
1) JIRA::Client initialization signature changed to one single options hash.
2) Support for HTTP Basic Auth along with OAuth.
3) Separation of concern into separate authentication classes, and corresponding tests.
4) Thoroughly tested, including extension of integration tests to easily add new authentication classes in the future.
5) Documentation updates, and a new http-basic-example.rb example.
6) Suggest a version number change of jira-ruby gem to v0.1.0 after this change is (hopefully) accepted.
