### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,3 +1,3 @@
 module JIRA
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
The 0.1.0 version on Rubygems has issues that have already been fixed in master (most notably, trineo/jira-ruby/#20).

Bump version so new gem generation will make 1.8.7 folks happy.
