### PR TITLE
Fixes an issue when status name contains spaces

### DIFF
--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -417,7 +417,7 @@ module JIRA
       if @attrs['self']
         @attrs['self']
       elsif key_value
-        self.class.singular_path(client, key_value.to_s, prefix)
+        self.class.singular_path(client, URI.encode(key_value.to_s), prefix)
       else
         self.class.collection_path(client, prefix)
       end

--- a/spec/jira/base_spec.rb
+++ b/spec/jira/base_spec.rb
@@ -334,6 +334,12 @@ describe JIRA::Base do
       attrs['id'] = '98765'
       subject.url.should == "/foo/bar/deadbeef/98765"
     end
+    
+    it "generates the encoded URL from key value" do
+      attrs['self'] = nil
+      attrs['id'] = 'foo bar'
+      subject.url.should == "/foo/bar/deadbeef/foo%20bar"
+    end
 
     it "generates the URL from collection_path if self and id not set" do
       attrs['self'] = nil


### PR DESCRIPTION
I tried to find a status by name, but got an error when that contains a space.

``` ruby
client.Status.find("In Progress")
JIRA::HTTPError: ...
```

So then, I tried to find a status again by url-encoded name. That was OK.

``` ruby
client.Status.find("In%20Progress")
=> #<JIRA::Resource::Status:...
```

I think client should accept non-url-encoded key value parameter. This is a patch.
Thanks!
