### PR TITLE
Update example.rb

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -1,13 +1,17 @@
 require 'pp'
 require './lib/jira'
 
+CONSUMER_KEY = 'test'
+SITE         = 'https://test.jira.com'
+
 options = {
-  :private_key_file => "rsakey.pem"
+  :private_key_file => "rsakey.pem",
+  :context_path     => '',
+  :consumer_key     => CONSUMER_KEY,
+  :site             => SITE
 }
 
-CONSUMER_KEY = 'test'
-
-client = JIRA::Client.new(CONSUMER_KEY, '', options)
+client = JIRA::Client.new(options)
 
 if ARGV.length == 0
   # If not passed any command line arguments, open a browser and prompt the


### PR DESCRIPTION
The old example.rb as out of date, as the initializer for `JIRA::Client` used to expect 3 arguments, a key, a secret, and options, and now all the data in the options.

The following error used to occur when running the example file:

```
/Users/kmazaika/source/jira-ruby/lib/jira/client.rb:54:in `initialize': wrong number of arguments (3 for 1) (ArgumentError)
    from example.rb:10:in `new'
    from example.rb:10:in `<main>'
```

This is fixed by using passing the arguments through the options hash.
