### PR TITLE
Use POST instead of GET for JQL searches to get around 50 item limit in OnDemand

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -40,8 +40,10 @@ module JIRA
       end
 
       def self.jql(client, jql)
-        url = client.options[:rest_base_path] + "/search?jql=" + CGI.escape(jql)
-        response = client.get(url)
+        url = client.options[:rest_base_path] + '/search'
+        request_body = { :jql => jql, :startAt => 0, :maxResults => 1000}
+        response = client.post(url, request_body.to_json)
+
         json = parse_json(response.body)
         json['issues'].map do |issue|
           client.Issue.build(issue)


### PR DESCRIPTION
We are using Atlassian OnDemand which apparently configures the JIRA REST API to a maxCount per page of 50. Since the jql query does not seem to iterate over pages I've changed the request to POST with an explicit max items of 1000. 

Probably not the best approach, are you already working on a different fix or is there a global configuration I should use to configure the client's default behaviour?
