### PR TITLE
Add a :max_results option to JIRA::Resource::Issue.jql search

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -44,6 +44,9 @@ module JIRA
         unless options[:max_results].nil?
           url += "&maxResults=" + options[:max_results].to_s
         end
+        unless options[:fields].nil?
+          url += "&fields=" + options[:fields].join(",")
+        end
         response = client.get(url)
         json = parse_json(response.body)
         json['issues'].map do |issue|

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -105,6 +105,16 @@ describe JIRA::Resource::Issue do
       JIRA::Resource::Issue.jql(client, 'project = Example', { :max_results => 200 })
     end
 
+    it "supports a fields option" do
+      client
+        .should_receive(:get)
+        .with("jira/rest/api/2/search?jql=project+%3D+Example&fields=summary,customfield_123")
+        .and_return(@response)
+      JIRA::Resource::Issue.jql(client, 'project = Example', {
+        :fields => [ "summary", "customfield_123" ],
+      })
+    end
+
   end
 
 end


### PR DESCRIPTION
I've found jira-ruby fulfils all my needs except this one tiny piece of missing functionality, so I thought I'd put together a pull request for it. I've copied the approach used by Jiralicious, which is to [accept an optional `options` hash](https://github.com/jstewart/jiralicious/blob/07d074b05d5d039797997dfff9d4de282e648aa8/lib/jiralicious/search.rb#L7-L9) as a catch-all for JIRA's various extra search parameters.

Please let me know if this isn't good enough to merge. I'll be happy to iterate on it until you're happy with it! :)
