### PR TITLE
Add support for transitions.

### DIFF
--- a/lib/jira.rb
+++ b/lib/jira.rb
@@ -20,6 +20,7 @@ require 'jira/resource/priority'
 require 'jira/resource/status'
 require 'jira/resource/comment'
 require 'jira/resource/worklog'
+require 'jira/resource/transition'
 require 'jira/resource/issue'
 
 require 'jira/request_client'

--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -249,6 +249,13 @@ module JIRA
       define_method(collection) do
         child_class_options = {self_class_basename => self}
         attribute = maybe_nested_attribute(attribute_key, options[:nested_under]) || []
+
+        if attribute.empty? && attrs["expand"] && attrs["expand"].split(",").include?(attribute_key)
+          response = client.get(url + "?expand=#{attribute_key}")
+          set_attrs_from_response(response)
+          attribute = maybe_nested_attribute(attribute_key, options[:nested_under]) || []
+        end
+
         collection = attribute.map do |child_attributes|
           child_class.new(client, child_class_options.merge(:attrs => child_attributes))
         end

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -111,6 +111,10 @@ module JIRA
       JIRA::Resource::VersionFactory.new(self)
     end
 
+    def Transition # :nodoc:
+      JIRA::Resource::TransitionFactory.new(self)
+    end
+
     # HTTP methods without a body
     def delete(path, headers = {})
       request(:delete, path, nil, merge_default_headers(headers))

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -31,6 +31,8 @@ module JIRA
 
       has_many :worklogs, :nested_under => ['fields','worklog']
 
+      has_many :transitions
+
       def self.all(client)
         response = client.get(client.options[:rest_base_path] + "/search")
         json = parse_json(response.body)

--- a/lib/jira/resource/transition.rb
+++ b/lib/jira/resource/transition.rb
@@ -1,0 +1,12 @@
+module JIRA
+  module Resource
+
+    class TransitionFactory < JIRA::BaseFactory # :nodoc:
+    end
+
+    class Transition < JIRA::Base
+      belongs_to :issue
+    end
+
+  end
+end

--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,3 +1,3 @@
 module JIRA
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -80,4 +80,27 @@ describe JIRA::Resource::Issue do
       subject.worklogs.length.should == 2
     end
   end
+
+  describe "unexpanded relationships" do
+    let(:url) {'jira_url'}
+    subject {
+      JIRA::Resource::Issue.new(client, :attrs => {
+        'id' => '123',
+        'expand' => "foo,bar,transitions,baz"
+      })
+    }
+    before {
+      JIRA::Resource::Issue.any_instance.stub(:url).and_return(url)
+      response = mock()
+      response.stub(:body).and_return('{"transitions":[{"id":1},{"id":2}],"id":"101"}')
+      client.should_receive(:get).with("#{url}?expand=transitions").and_return(response)
+    }
+
+    it "has the correct relationships" do
+      subject.should have_many(:transitions, JIRA::Resource::Transition)
+      subject.transitions.count.should == 2
+      subject.transitions.first.id.should == 1
+      subject.transitions.last.id.should == 2
+    end
+  end
 end


### PR DESCRIPTION
Transitions aren't expanded by default when fetching an issue, so add
support to JIRA::Base.has_many for expanding attributes that aren't
already present when trying to build a collection list.

This is very handy when dealing with custom transition workflows.
