### PR TITLE
Use a more common user agent

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -48,7 +48,11 @@ module JIRA
       :rest_base_path     => "/rest/api/2",
       :ssl_verify_mode    => OpenSSL::SSL::VERIFY_PEER,
       :use_ssl            => true,
-      :auth_type          => :oauth
+      :auth_type          => :oauth,
+      :default_headers    => {
+        'User-Agent' => 'Mozilla/4.0',
+        'Accept'     => 'application/json'
+      }
     }
 
     def initialize(options={})
@@ -144,7 +148,7 @@ module JIRA
     protected
 
       def merge_default_headers(headers)
-        {'Accept' => 'application/json'}.merge(headers)
+        @options[:default_headers].merge(headers)
       end
 
   end


### PR DESCRIPTION
Some jira instances are configured to redirect all suspicious (i.e non
common) user agent to captcha challenge when authenticating.
We add a default user-agent "Mozilla/4.0" recommended by curl manual
page to avoid the default "ruby" UA which is not that common.
