### PR TITLE
update the brew install link

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,7 +30,7 @@ This gem provides access to the Atlassian JIRA REST API.
 
 On Mac OS,
 
-    brew install atlassian-plugin-sdk
+    brew install atlassian/tap/atlassian-plugin-sdk
 
 Otherwise:
 


### PR DESCRIPTION
The brew install link for the atlassian-plugin-sdk seems to be broken.

```
$ brew install atlassian-plugin-sdk
Error: No available formula for atlassian-plugin-sdk 
Searching taps...
```

But found a working command on https://developer.atlassian.com/display/DOCS/Install+the+Atlassian+SDK+on+a+Linux+or+Mac+System

```
$ brew install atlassian/tap/atlassian-plugin-sdk
Cloning into '/opt/twitter/Library/Taps/atlassian-tap'...
remote: Reusing existing pack: 67, done.
remote: Total 67 (delta 0), reused 0 (delta 0)
Unpacking objects: 100% (67/67), done.
Checking connectivity... done.
Tapped 1 formula
==> Downloading https://maven.atlassian.com/content/repositories/atlassian-public/com/atlassian/amps/atlassian-plugin-sdk/4.2.10/atlassian-plugin-sdk-4.2.10.tar.gz
######################################################################## 100.0%
==> Caveats
Thanks for installing the Atlassian Plugin SDK. For more information,
visit https://developer.atlassian.com.

To create a plugin skeleton using atlas-create-APPLICATION-plugin, e.g.:
  atlas-create-jira-plugin or atlas-create-confluence-plugin

To run your plugin's host application with the plugin skeleton installed:
  atlas-run
==> Summary
```
