### PR TITLE
Assign certificate store default paths to the Net::HTTP connection

### DIFF
--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -36,6 +36,8 @@ module JIRA
       http_conn = http_class.new(uri.host, uri.port)
       http_conn.use_ssl = @options[:use_ssl]
       http_conn.verify_mode = @options[:ssl_verify_mode]
+      http_conn.cert_store = OpenSSL::X509::Store.new
+      http_conn.cert_store.set_default_paths
       http_conn
     end
 

--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,3 +1,3 @@
 module JIRA
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,3 +1,3 @@
 module JIRA
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,3 +1,3 @@
 module JIRA
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -59,11 +59,16 @@ describe JIRA::HttpClient do
     uri = double()
     host = double()
     port = double()
+    cert_store = double()
     uri.should_receive(:host).and_return(host)
     uri.should_receive(:port).and_return(port)
     Net::HTTP.should_receive(:new).with(host, port).and_return(http_conn)
     http_conn.should_receive(:use_ssl=).with(basic_client.options[:use_ssl]).and_return(http_conn)
     http_conn.should_receive(:verify_mode=).with(basic_client.options[:ssl_verify_mode]).and_return(http_conn)
+    OpenSSL::X509::Store.should_receive(:new).and_return(cert_store)
+    http_conn.should_receive(:cert_store=).with(cert_store).and_return(cert_store)
+    http_conn.should_receive(:cert_store).and_return(cert_store)
+    cert_store.should_receive(:set_default_paths).and_return(nil)
     basic_client.http_conn(uri).should == http_conn
   end
 


### PR DESCRIPTION
This fix alleviated the "SSL_connect returned=1 errno=0 state=SSLv3 read
server certificate" error occuring on a CentOS release 6.4 (Final) Linux
system.