### PR TITLE
Support query params in Base#init, Base#fetch and Project#issues.

### DIFF
--- a/lib/jira/resource/project.rb
+++ b/lib/jira/resource/project.rb
@@ -16,15 +16,16 @@ module JIRA
       end
 
       # Returns all the issues for this project
-      def issues
-        response = client.get(client.options[:rest_base_path] + "/search?jql=project%3D'#{key}'")
+      def issues(options={})
+        search_url = client.options[:rest_base_path] + '/search'
+        query_params = {:jql => "project=\"#{key}\""}
+        query_params.update Base.query_params_for_search(options)
+        response = client.get(url_with_query_params(search_url, query_params))
         json = self.class.parse_json(response.body)
         json['issues'].map do |issue|
           client.Issue.build(issue)
         end
       end
-
     end
-
   end
 end

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -26,7 +26,7 @@ describe JIRA::Resource::Project do
     describe "issues" do
 
       it "returns all the issues" do
-        stub_request(:get, site_url + "/jira/rest/api/2/search?jql=project='SAMPLEPROJECT'").
+        stub_request(:get, site_url + "/jira/rest/api/2/search?jql=project=\"SAMPLEPROJECT\"").
           to_return(:status => 200, :body => get_mock_response('project/SAMPLEPROJECT.issues.json'))
         subject = client.Project.build('key' => key)
         issues = subject.issues

--- a/spec/jira/base_spec.rb
+++ b/spec/jira/base_spec.rb
@@ -67,6 +67,21 @@ describe JIRA::Base do
     deadbeef.expanded?.should be_true
   end
 
+  it "finds a deadbeef containing changelog by id" do
+    response = double() 
+    response.stub(:body).and_return('{"self":"http://deadbeef/","id":"98765","changelog":{"histories":[]}}')
+    client.should_receive(:get).with('/jira/rest/api/2/deadbeef/98765?expand=changelog').and_return(response)
+
+    JIRA::Resource::Deadbeef.should_receive(:collection_path).and_return('/jira/rest/api/2/deadbeef')
+
+    deadbeef = JIRA::Resource::Deadbeef.find(client, '98765', {expand:'changelog'})
+    deadbeef.client.should == client
+    deadbeef.attrs['self'].should  == 'http://deadbeef/'
+    deadbeef.attrs['id'].should   == '98765'
+    deadbeef.expanded?.should be_true
+    deadbeef.attrs['changelog']['histories'].should == []
+  end
+
   it "builds a deadbeef" do
     deadbeef = JIRA::Resource::Deadbeef.build(client, 'id' => "98765" )
     deadbeef.expanded?.should be_false
@@ -176,6 +191,21 @@ describe JIRA::Base do
       end
     end
 
+    context "with expand parameter 'changelog'" do
+      it "fetchs changelogs '" do
+        response = double() 
+        response.stub(:body).and_return('{"self":"http://deadbeef/","id":"98765","changelog":{"histories":[]}}')
+        client.should_receive(:get).with('/jira/rest/api/2/deadbeef/98765?expand=changelog').and_return(response)
+
+        JIRA::Resource::Deadbeef.should_receive(:collection_path).and_return('/jira/rest/api/2/deadbeef')
+
+        subject.fetch(false, {expand:'changelog'})
+
+        subject.self.should == "http://deadbeef/"
+        subject.id.should  == "98765"
+        subject.changelog['histories'].should == []
+      end
+    end
   end
 
   describe "save" do

--- a/spec/jira/resource/project_spec.rb
+++ b/spec/jira/resource/project_spec.rb
@@ -2,14 +2,17 @@ require 'spec_helper'
 
 describe JIRA::Resource::Project do
 
-  let(:client) { double() }
+  let(:client) { double("client", :options => {
+                          :rest_base_path => '/jira/rest/api/2'
+                        })
+  }
 
   describe "relationships" do
     subject {
       JIRA::Resource::Project.new(client, :attrs => {
-        'lead'        => {'foo' => 'bar'},
-        'issueTypes'  => [{'foo' =>'bar'},{'baz' => 'flum'}],
-        'versions'    => [{'foo' =>'bar'},{'baz' => 'flum'}]
+          'lead'        => {'foo' => 'bar'},
+          'issueTypes'  => [{'foo' =>'bar'},{'baz' => 'flum'}],
+          'versions'    => [{'foo' =>'bar'},{'baz' => 'flum'}],
       })
     }
 
@@ -25,4 +28,43 @@ describe JIRA::Resource::Project do
     end
   end
 
+  describe "issues" do
+    subject {
+      JIRA::Resource::Project.new(client, :attrs => {
+          'key'         => 'test'
+        })
+    }
+
+    it "returns issues" do
+      response_body = '{"expand":"schema,names","startAt":0,"maxResults":1,"total":1,"issues":[{"expand":"editmeta,renderedFields,transitions,changelog,operations","id":"53062","self":"/rest/api/2/issue/53062","key":"test key","fields":{"summary":"test summary"}}]}'
+      response = double("response",
+        :body => response_body)
+      issue_factory = double("issue factory")
+
+      client.should_receive(:get)
+        .with('/jira/rest/api/2/search?jql=project%3D%22test%22')
+        .and_return(response)
+      client.should_receive(:Issue).and_return(issue_factory)
+      issue_factory.should_receive(:build)
+        .with(JSON.parse(response_body)["issues"][0])
+      subject.issues
+    end
+
+    context "with changelog" do
+      it "returns issues" do
+        response_body = '{"expand":"schema,names","startAt":0,"maxResults":1,"total":1,"issues":[{"expand":"editmeta,renderedFields,transitions,changelog,operations","id":"53062","self":"/rest/api/2/issue/53062","key":"test key","fields":{"summary":"test summary"},"changelog":{}}]}'
+        response = double("response",
+          :body => response_body)
+        issue_factory = double("issue factory")
+
+        client.should_receive(:get)
+          .with('/jira/rest/api/2/search?jql=project%3D%22test%22&expand=changelog&startAt=1&maxResults=100')
+          .and_return(response)
+        client.should_receive(:Issue).and_return(issue_factory)
+        issue_factory.should_receive(:build)
+          .with(JSON.parse(response_body)["issues"][0])
+        subject.issues({expand:'changelog', startAt:1, maxResults:100})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This patch allows users to specify the extend and fields parameter in the options
argument of Base#find to fetch extra information such as changelog.

By using this, you can fetch the changelog of an issue as
follows:

issue = client.Issue.find('MYPROJ-10, {expand:'changelog'})
issue.changelog['histories'].each do |c|
 ...
end

I'm not sure this patch fits with the original design. Please review it.
