### PR TITLE
Update issue.rb to not escape &fields query parameter

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -46,7 +46,7 @@ module JIRA
 
       def self.jql(client, jql, fields = nil)
         url = client.options[:rest_base_path] + "/search?jql=" + CGI.escape(jql)
-        url += CGI.escape("&fields=#{fields.join(",")}") if fields
+        url += "&fields=" + CGI.escape(fields.join(",")) if fields
         response = client.get(url)
         json = parse_json(response.body)
         json['issues'].map do |issue|


### PR DESCRIPTION
Don't escape &fields part of the URL when specifying fields to return in a jql Issue query.

When I was issuing requests like this:
issues = client.Issue.jql(request, ["summary"])
I was getting this error:
C:/Ruby193/lib/ruby/gems/1.9.1/gems/jira-ruby-0.1.10/lib/jira/request_client.rb:14:in `request': Bad Request (JIRA::HTTPError)

This change resolves that problem.
