### PR TITLE
Added basic RapidViews(Agile boards) support

### DIFF
--- a/lib/jira.rb
+++ b/lib/jira.rb
@@ -24,6 +24,7 @@ require 'jira/resource/worklog'
 require 'jira/resource/issue'
 require 'jira/resource/filter'
 require 'jira/resource/field'
+require 'jira/resource/rapidview'
 
 require 'jira/request_client'
 require 'jira/oauth_client'

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -125,6 +125,10 @@ module JIRA
       JIRA::Resource::FieldFactory.new(self)
     end
 
+    def RapidView
+      JIRA::Resource::RapidViewFactory.new(self)
+    end
+
     # HTTP methods without a body
     def delete(path, headers = {})
       request(:delete, path, nil, merge_default_headers(headers))

--- a/lib/jira/resource/rapidview.rb
+++ b/lib/jira/resource/rapidview.rb
@@ -1,0 +1,46 @@
+require 'cgi'
+
+module JIRA
+  module Resource
+
+    class RapidViewFactory < JIRA::BaseFactory # :nodoc:
+    end
+
+    class RapidView < JIRA::Base
+
+      def self.all(client)
+        response = client.get(path_base(client) + '/rapidview')
+        json = parse_json(response.body)
+        json['views'].map do |view|
+          client.RapidView.build(view)
+        end
+      end
+
+      def self.find(client, key, options = {})
+        response = client.get(path_base(client) + "/rapidview/#{key}")
+        json = parse_json(response.body)
+        client.RapidView.build(json)
+      end
+
+      def issues
+        response = client.get(path_base(client) + "/xboard/plan/backlog/data?rapidViewId=#{id}")
+        json = self.class.parse_json(response.body)
+        # To get Issue objects with the same structure as for Issue.all
+        issue_ids = json['issues'].map { |issue| issue['id'] }
+        client.Issue.jql("id IN(#{issue_ids.join(', ')})")
+      end
+
+      private
+
+      def self.path_base(client)
+        client.options[:context_path] + '/rest/greenhopper/1.0'
+      end
+
+      def path_base(client)
+        self.class.path_base(client)
+      end
+
+    end
+
+  end
+end

--- a/spec/integration/rapidview_spec.rb
+++ b/spec/integration/rapidview_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe JIRA::Resource::RapidView do
+
+  with_each_client do |site_url, client|
+    let(:client) { client }
+    let(:site_url) { site_url }
+
+    let(:key) { '1' }
+
+    let(:expected_collection_length) { 1 }
+
+    let(:expected_attributes) {
+      {
+        'id' => 1,
+        'name' => 'SAMPLEPROJECT',
+        'canEdit' => true,
+        'sprintSupportEnabled' => true
+      }
+    }
+
+    it_should_behave_like 'a resource'
+    # TODO@Anton: Add json file
+    # it_should_behave_like 'a resource with a singular GET endpoint'
+
+    describe 'GET all rapidviews' do
+      let(:client) { client }
+      let(:site_url) { site_url }
+
+      before(:each) do
+        stub_request(:get, site_url + '/jira/rest/greenhopper/1.0/rapidview').
+        to_return(:status => 200, :body => get_mock_response('rapidview.json'))
+      end
+      it_should_behave_like 'a resource with a collection GET endpoint'
+    end
+
+    describe 'issues' do
+      it 'should return all the issues' do
+        stub_request(
+          :get,
+          site_url +
+          '/jira/rest/greenhopper/1.0/xboard/plan/backlog/data?rapidViewId=1'
+        ).to_return(
+          :status => 200,
+          :body => get_mock_response('rapidview/SAMPLEPROJECT.issues.json')
+        )
+
+        stub_request(
+          :get,
+          site_url + '/jira/rest/api/2/search?jql=id IN(10000, 10001)'
+        ).to_return(
+          :status => 200,
+          :body => get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json')
+        )
+
+        subject = client.RapidView.build('id' => 1)
+        issues = subject.issues
+        expect(issues.length).to eq(2)
+
+        issues.each do |issue|
+          expect(issue.class).to eq(JIRA::Resource::Issue)
+          expect(issue.expanded?).to be_falsey
+        end
+      end
+    end
+  end
+end

--- a/spec/mock_responses/rapidview.json
+++ b/spec/mock_responses/rapidview.json
@@ -1,0 +1,10 @@
+{
+  "views": [
+     {
+       "id": 1,
+       "name": "SAMPLEPROJECT",
+       "canEdit": true,
+       "sprintSupportEnabled": true
+     }
+  ]
+}

--- a/spec/mock_responses/rapidview/SAMPLEPROJECT.issues.full.json
+++ b/spec/mock_responses/rapidview/SAMPLEPROJECT.issues.full.json
@@ -1,0 +1,276 @@
+{
+    "expand": "schema,names",
+    "startAt": 0,
+    "maxResults": 50,
+    "total": 2,
+    "issues": [
+        {
+            "expand": "editmeta,renderedFields,transitions,changelog,operations",
+            "id": "10001",
+            "self": "http://localhost:2990/jira/rest/api/2/issue/10001",
+            "key": "SAM-2",
+            "fields": {
+                "summary": "Test issue 2",
+                "progress": {
+                    "progress": 0,
+                    "total": 0
+                },
+                "issuetype": {
+                    "self": "http://localhost:2990/jira/rest/api/2/issuetype/10001",
+                    "id": "10001",
+                    "description": "",
+                    "iconUrl": "http://localhost:2990/jira/images/icons/ico_story.png",
+                    "name": "Story",
+                    "subtask": false
+                },
+                "votes": {
+                    "self": "http://localhost:2990/jira/rest/api/2/issue/SAM-2/votes",
+                    "votes": 0,
+                    "hasVoted": false
+                },
+                "resolution": null,
+                "fixVersions": [],
+                "resolutiondate": null,
+                "timespent": null,
+                "creator": {
+                    "self": "http://localhost:2990/jira/rest/api/2/user?username=admin",
+                    "name": "admin",
+                    "emailAddress": "admin@example.com",
+                    "avatarUrls": {
+                        "16x16": "http://localhost:2990/jira/secure/useravatar?size=xsmall&avatarId=10122",
+                        "24x24": "http://localhost:2990/jira/secure/useravatar?size=small&avatarId=10122",
+                        "32x32": "http://localhost:2990/jira/secure/useravatar?size=medium&avatarId=10122",
+                        "48x48": "http://localhost:2990/jira/secure/useravatar?avatarId=10122"
+                    },
+                    "displayName": "admin",
+                    "active": true
+                },
+                "reporter": {
+                    "self": "http://localhost:2990/jira/rest/api/2/user?username=admin",
+                    "name": "admin",
+                    "emailAddress": "admin@example.com",
+                    "avatarUrls": {
+                        "16x16": "http://localhost:2990/jira/secure/useravatar?size=xsmall&avatarId=10122",
+                        "24x24": "http://localhost:2990/jira/secure/useravatar?size=small&avatarId=10122",
+                        "32x32": "http://localhost:2990/jira/secure/useravatar?size=medium&avatarId=10122",
+                        "48x48": "http://localhost:2990/jira/secure/useravatar?avatarId=10122"
+                    },
+                    "displayName": "admin",
+                    "active": true
+                },
+                "aggregatetimeoriginalestimate": null,
+                "created": "2014-07-18T23:30:43.000+0700",
+                "updated": "2014-07-18T23:30:44.000+0700",
+                "description": null,
+                "priority": {
+                    "self": "http://localhost:2990/jira/rest/api/2/priority/3",
+                    "iconUrl": "http://localhost:2990/jira/images/icons/priorities/major.png",
+                    "name": "Major",
+                    "id": "3"
+                },
+                "duedate": null,
+                "customfield_10001": null,
+                "customfield_10002": null,
+                "customfield_10003": null,
+                "issuelinks": [],
+                "customfield_10004": null,
+                "watches": {
+                    "self": "http://localhost:2990/jira/rest/api/2/issue/SAM-2/watchers",
+                    "watchCount": 1,
+                    "isWatching": true
+                },
+                "customfield_10000": null,
+                "subtasks": [],
+                "customfield_10009": "0|100004:",
+                "status": {
+                    "self": "http://localhost:2990/jira/rest/api/2/status/1",
+                    "description": "The issue is open and ready for the assignee to start work on it.",
+                    "iconUrl": "http://localhost:2990/jira/images/icons/statuses/open.png",
+                    "name": "Open",
+                    "id": "1",
+                    "statusCategory": {
+                        "self": "http://localhost:2990/jira/rest/api/2/statuscategory/2",
+                        "id": 2,
+                        "key": "new",
+                        "colorName": "blue-gray",
+                        "name": "New"
+                    }
+                },
+                "labels": [],
+                "customfield_10005": null,
+                "workratio": -1,
+                "assignee": {
+                    "self": "http://localhost:2990/jira/rest/api/2/user?username=admin",
+                    "name": "admin",
+                    "emailAddress": "admin@example.com",
+                    "avatarUrls": {
+                        "16x16": "http://localhost:2990/jira/secure/useravatar?size=xsmall&avatarId=10122",
+                        "24x24": "http://localhost:2990/jira/secure/useravatar?size=small&avatarId=10122",
+                        "32x32": "http://localhost:2990/jira/secure/useravatar?size=medium&avatarId=10122",
+                        "48x48": "http://localhost:2990/jira/secure/useravatar?avatarId=10122"
+                    },
+                    "displayName": "admin",
+                    "active": true
+                },
+                "aggregatetimeestimate": null,
+                "project": {
+                    "self": "http://localhost:2990/jira/rest/api/2/project/10000",
+                    "id": "10000",
+                    "key": "SAM",
+                    "name": "SAMPLEPROJECT",
+                    "avatarUrls": {
+                        "16x16": "http://localhost:2990/jira/secure/projectavatar?size=xsmall&pid=10000&avatarId=10011",
+                        "24x24": "http://localhost:2990/jira/secure/projectavatar?size=small&pid=10000&avatarId=10011",
+                        "32x32": "http://localhost:2990/jira/secure/projectavatar?size=medium&pid=10000&avatarId=10011",
+                        "48x48": "http://localhost:2990/jira/secure/projectavatar?pid=10000&avatarId=10011"
+                    }
+                },
+                "versions": [],
+                "environment": null,
+                "timeestimate": null,
+                "aggregateprogress": {
+                    "progress": 0,
+                    "total": 0
+                },
+                "lastViewed": "2014-07-18T23:30:43.561+0700",
+                "components": [],
+                "timeoriginalestimate": null,
+                "aggregatetimespent": null
+            }
+        },
+        {
+            "expand": "editmeta,renderedFields,transitions,changelog,operations",
+            "id": "10000",
+            "self": "http://localhost:2990/jira/rest/api/2/issue/10000",
+            "key": "SAM-1",
+            "fields": {
+                "summary": "Test issue 1",
+                "progress": {
+                    "progress": 0,
+                    "total": 0
+                },
+                "issuetype": {
+                    "self": "http://localhost:2990/jira/rest/api/2/issuetype/10001",
+                    "id": "10001",
+                    "description": "",
+                    "iconUrl": "http://localhost:2990/jira/images/icons/ico_story.png",
+                    "name": "Story",
+                    "subtask": false
+                },
+                "votes": {
+                    "self": "http://localhost:2990/jira/rest/api/2/issue/SAM-1/votes",
+                    "votes": 0,
+                    "hasVoted": false
+                },
+                "resolution": null,
+                "fixVersions": [],
+                "resolutiondate": null,
+                "timespent": null,
+                "creator": {
+                    "self": "http://localhost:2990/jira/rest/api/2/user?username=admin",
+                    "name": "admin",
+                    "emailAddress": "admin@example.com",
+                    "avatarUrls": {
+                        "16x16": "http://localhost:2990/jira/secure/useravatar?size=xsmall&avatarId=10122",
+                        "24x24": "http://localhost:2990/jira/secure/useravatar?size=small&avatarId=10122",
+                        "32x32": "http://localhost:2990/jira/secure/useravatar?size=medium&avatarId=10122",
+                        "48x48": "http://localhost:2990/jira/secure/useravatar?avatarId=10122"
+                    },
+                    "displayName": "admin",
+                    "active": true
+                },
+                "reporter": {
+                    "self": "http://localhost:2990/jira/rest/api/2/user?username=admin",
+                    "name": "admin",
+                    "emailAddress": "admin@example.com",
+                    "avatarUrls": {
+                        "16x16": "http://localhost:2990/jira/secure/useravatar?size=xsmall&avatarId=10122",
+                        "24x24": "http://localhost:2990/jira/secure/useravatar?size=small&avatarId=10122",
+                        "32x32": "http://localhost:2990/jira/secure/useravatar?size=medium&avatarId=10122",
+                        "48x48": "http://localhost:2990/jira/secure/useravatar?avatarId=10122"
+                    },
+                    "displayName": "admin",
+                    "active": true
+                },
+                "aggregatetimeoriginalestimate": null,
+                "created": "2014-07-18T23:30:26.000+0700",
+                "updated": "2014-07-18T23:30:26.000+0700",
+                "description": null,
+                "priority": {
+                    "self": "http://localhost:2990/jira/rest/api/2/priority/3",
+                    "iconUrl": "http://localhost:2990/jira/images/icons/priorities/major.png",
+                    "name": "Major",
+                    "id": "3"
+                },
+                "duedate": null,
+                "customfield_10001": null,
+                "customfield_10002": null,
+                "customfield_10003": null,
+                "issuelinks": [],
+                "customfield_10004": null,
+                "watches": {
+                    "self": "http://localhost:2990/jira/rest/api/2/issue/SAM-1/watchers",
+                    "watchCount": 1,
+                    "isWatching": true
+                },
+                "customfield_10000": null,
+                "subtasks": [],
+                "customfield_10009": "0|100000:",
+                "status": {
+                    "self": "http://localhost:2990/jira/rest/api/2/status/1",
+                    "description": "The issue is open and ready for the assignee to start work on it.",
+                    "iconUrl": "http://localhost:2990/jira/images/icons/statuses/open.png",
+                    "name": "Open",
+                    "id": "1",
+                    "statusCategory": {
+                        "self": "http://localhost:2990/jira/rest/api/2/statuscategory/2",
+                        "id": 2,
+                        "key": "new",
+                        "colorName": "blue-gray",
+                        "name": "New"
+                    }
+                },
+                "labels": [],
+                "customfield_10005": null,
+                "workratio": -1,
+                "assignee": {
+                    "self": "http://localhost:2990/jira/rest/api/2/user?username=admin",
+                    "name": "admin",
+                    "emailAddress": "admin@example.com",
+                    "avatarUrls": {
+                        "16x16": "http://localhost:2990/jira/secure/useravatar?size=xsmall&avatarId=10122",
+                        "24x24": "http://localhost:2990/jira/secure/useravatar?size=small&avatarId=10122",
+                        "32x32": "http://localhost:2990/jira/secure/useravatar?size=medium&avatarId=10122",
+                        "48x48": "http://localhost:2990/jira/secure/useravatar?avatarId=10122"
+                    },
+                    "displayName": "admin",
+                    "active": true
+                },
+                "aggregatetimeestimate": null,
+                "project": {
+                    "self": "http://localhost:2990/jira/rest/api/2/project/10000",
+                    "id": "10000",
+                    "key": "SAM",
+                    "name": "SAMPLEPROJECT",
+                    "avatarUrls": {
+                        "16x16": "http://localhost:2990/jira/secure/projectavatar?size=xsmall&pid=10000&avatarId=10011",
+                        "24x24": "http://localhost:2990/jira/secure/projectavatar?size=small&pid=10000&avatarId=10011",
+                        "32x32": "http://localhost:2990/jira/secure/projectavatar?size=medium&pid=10000&avatarId=10011",
+                        "48x48": "http://localhost:2990/jira/secure/projectavatar?pid=10000&avatarId=10011"
+                    }
+                },
+                "versions": [],
+                "environment": null,
+                "timeestimate": null,
+                "aggregateprogress": {
+                    "progress": 0,
+                    "total": 0
+                },
+                "lastViewed": "2014-07-18T23:30:28.576+0700",
+                "components": [],
+                "timeoriginalestimate": null,
+                "aggregatetimespent": null
+            }
+        }
+    ]
+}

--- a/spec/mock_responses/rapidview/SAMPLEPROJECT.issues.json
+++ b/spec/mock_responses/rapidview/SAMPLEPROJECT.issues.json
@@ -1,0 +1,111 @@
+{
+  "sprintMarkersMigrated": true,
+  "issues": [
+    {
+      "id": 10000,
+      "key": "SAM-1",
+      "hidden": false,
+      "typeName": "Story",
+      "typeId": "10001",
+      "summary": "Test issue 1",
+      "typeUrl": "http://localhost:2990/jira/images/icons/ico_story.png",
+      "priorityUrl": "http://localhost:2990/jira/images/icons/priorities/major.png",
+      "priorityName": "Major",
+      "done": false,
+      "assignee": "admin",
+      "assigneeName": "admin",
+      "hasCustomUserAvatar": false,
+      "autoUserAvatar": {
+        "letter": "a",
+        "color": "#f691b2"
+        },
+      "color": "#cc0000",
+      "estimateStatistic": {
+        "statFieldId": "customfield_10002",
+        "statFieldValue": {}
+        },
+      "statusId": "1",
+      "statusName": "Open",
+      "statusUrl": "http://localhost:2990/jira/images/icons/statuses/open.png",
+      "status": {
+        "id": "1",
+        "name": "Open",
+        "description": "The issue is open and ready for the assignee to start work on it.",
+        "iconUrl": "http://localhost:2990/jira/images/icons/statuses/open.png",
+        "statusCategory": {
+          "id": "2",
+          "key": "new",
+          "colorName": "blue-gray"
+        }
+      },
+      "fixVersions": [],
+      "projectId": 10000,
+      "linkedPagesCount": 0
+    },
+    {
+      "id": 10001,
+      "key": "SAM-2",
+      "hidden": false,
+      "typeName": "Story",
+      "typeId": "10001",
+      "summary": "Test issue 2",
+      "typeUrl": "http://localhost:2990/jira/images/icons/ico_story.png",
+      "priorityUrl": "http://localhost:2990/jira/images/icons/priorities/major.png",
+      "priorityName": "Major",
+      "done": false,
+      "assignee": "admin",
+      "assigneeName": "admin",
+      "hasCustomUserAvatar": false,
+      "autoUserAvatar": {
+        "letter": "a",
+        "color": "#f691b2"
+      },
+      "color": "#cc0000",
+        "estimateStatistic": {
+          "statFieldId": "customfield_10002",
+          "statFieldValue": {}
+        },
+          "statusId": "1",
+          "statusName": "Open",
+          "statusUrl": "http://localhost:2990/jira/images/icons/statuses/open.png",
+          "status": {
+            "id": "1",
+            "name": "Open",
+            "description": "The issue is open and ready for the assignee to start work on it.",
+            "iconUrl": "http://localhost:2990/jira/images/icons/statuses/open.png",
+            "statusCategory": {
+              "id": "2",
+              "key": "new",
+              "colorName": "blue-gray"
+            }
+          },
+          "fixVersions": [],
+          "projectId": 10000,
+          "linkedPagesCount": 0
+    }
+  ],
+  "rankCustomFieldId": 10009,
+  "sprints": [],
+  "supportsPages": false,
+  "projects": [
+    {
+      "id": 10000,
+      "key": "SAM",
+      "name": "SAMPLEPROJECT"
+    }
+  ],
+  "epicData": {
+    "epics": [],
+    "canEditEpics": false,
+    "supportsPages": false
+  },
+  "canManageSprints": true,
+  "maxIssuesExceeded": false,
+  "queryResultLimit": 2147483647,
+  "versionData": {
+    "versionsPerProject": {
+      "10000": []
+    },
+    "canCreateVersion": true
+  }
+}

--- a/spec/mock_responses/rapidview/SAMPLEPROJECT.json
+++ b/spec/mock_responses/rapidview/SAMPLEPROJECT.json
@@ -1,0 +1,6 @@
+{
+  "id": 1,
+  "name": "SAMPLEPROJECT",
+  "canEdit": true,
+  "sprintSupportEnabled": true
+}


### PR DESCRIPTION
Added basic support for JIRA Agile boards.

Usage:
```ruby
client = JIRA::Client.new(options)
# Get all rapid boards
boards = client.RapidView.all
# Or find one
board = client.RapidView.find(1)
# Get all issues related to a board
issues = board.issues
```

Probably will also need to add descriptive error messages when trying to get boards from non-agile JIRA instance.