### PR TITLE
Fix bug in Issue.all where client is passed bad arguments

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -34,10 +34,8 @@ module JIRA
       has_many :worklogs, :nested_under => ['fields','worklog']
 
       def self.all(client)
-        response = client.get(
-          client.options[:rest_base_path] + "/search",
-          :expand => 'transitions.fields'
-        )
+        url = client.options[:rest_base_path] + "/search?expand=transitions.fields"
+        response = client.get(url)
         json = parse_json(response.body)
         json['issues'].map do |issue|
           client.Issue.build(issue)

--- a/spec/integration/issue_spec.rb
+++ b/spec/integration/issue_spec.rb
@@ -46,7 +46,7 @@ describe JIRA::Resource::Issue do
         }
       }
       before(:each) do
-        stub_request(:get, site_url + "/jira/rest/api/2/search").
+        stub_request(:get, site_url + "/jira/rest/api/2/search?expand=transitions.fields").
                     to_return(:status => 200, :body => get_mock_response('issue.json'))
       end
       it_should_behave_like "a resource with a collection GET endpoint"

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -29,8 +29,23 @@ describe JIRA::Resource::Issue do
       end
     end
   end
+
+  it "should find all issues" do
+    response = double()
+    issue = double()
+
+    allow(response).to receive(:body).and_return('{"issues":[{"id":"1","summary":"Bugs Everywhere"}]}')
+    expect(client).to receive(:get).with('/jira/rest/api/2/search?expand=transitions.fields').
+      and_return(response)
+    expect(client).to receive(:Issue).and_return(issue)
+    expect(issue).to receive(:build).with({"id"=>"1","summary"=>"Bugs Everywhere"})
+
+    issues = JIRA::Resource::Issue.all(client)
+  end
+
   it "should find an issue by key or id" do
     response = double()
+
     allow(response).to receive(:body).and_return('{"key":"foo","id":"101"}')
     allow(JIRA::Resource::Issue).to receive(:collection_path).and_return('/jira/rest/api/2/issue')
     expect(client).to receive(:get).with('/jira/rest/api/2/issue/foo').
@@ -47,6 +62,7 @@ describe JIRA::Resource::Issue do
   it "should search an issue with a jql query string" do
     response = double()
     issue = double()
+
     allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
     expect(client).to receive(:get).with('/jira/rest/api/2/search?jql=foo+bar').
       and_return(response)


### PR DESCRIPTION
This pull request fixes the bug mentioned in issue #69 where `Issue.all` was passing the wrong arguments to `client.get`. This PR fixes this by constructing the correct URL and adds tests that were missing (or hadn't been updated).