### PR TITLE
Added extra options to pass to Consumer#get_request_token

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -163,7 +163,8 @@ Create a controller for handling the OAuth conversation.
     before_filter :get_jira_client
 
     def new
-      request_token = @jira_client.request_token
+      callback_url = 'http://callback'
+      request_token = @jira_client.request_token(oauth_callback: callback_url)
       session[:request_token] = request_token.token
       session[:request_secret] = request_token.secret
 

--- a/lib/jira/oauth_client.rb
+++ b/lib/jira/oauth_client.rb
@@ -44,8 +44,8 @@ module JIRA
 
     # Returns the current request token if it is set, else it creates
     # and sets a new token.
-    def request_token
-      @request_token ||= get_request_token
+    def request_token(options = {}, *arguments, &block)
+      @request_token ||= get_request_token(options, *arguments, block)
     end
 
     # Sets the request token from a given token and secret.


### PR DESCRIPTION
Doing this in order to be able to pass Consumer#get_request_token (oauth) some extra parameters (oauth_callback, for instance).
See http://rubydoc.info/gems/oauth/0.4.7/OAuth/Consumer