### PR TITLE
Remove version constraint from Active Support dependency.

### DIFF
--- a/jira-ruby.gemspec
+++ b/jira-ruby.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "railties", '~> 4.1.4'
   s.add_runtime_dependency "oauth", '~> 0.4.7'
-  s.add_runtime_dependency "activesupport", '~> 4.1.4'
+  s.add_runtime_dependency "activesupport"
+
+  s.add_development_dependency "railties", '~> 4.1.4'
   s.add_development_dependency "webmock", '~> 1.18.0'
   s.add_development_dependency "rspec", '~> 3.0.0'
   s.add_development_dependency "rake", '~> 10.3.2'
 end
-


### PR DESCRIPTION
This PR removes the version constraint for the Active Support dependency. This will allow `jira-ruby` to support multiple versions of Rails (including 4.2). This fixes #96.

If we are concerned about compatibility with different versions of Active Support, we can start using [Appraisal](https://github.com/thoughtbot/appraisal) to test compatibility against different gem versions. I would be happy to set that up if you want me to.