### PR TITLE
Add support for specifying expand in Issue.jql

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -44,12 +44,17 @@ module JIRA
         end
       end
 
-      def self.jql(client, jql, options = {fields: nil, start_at: nil, max_results: nil})
+      def self.jql(client, jql, options = {fields: nil, start_at: nil, max_results: nil, expand: nil})
         url = client.options[:rest_base_path] + "/search?jql=" + CGI.escape(jql)
 
         url << "&fields=#{options[:fields].map{ |value| CGI.escape(value.to_s) }.join(',')}" if options[:fields]
         url << "&startAt=#{CGI.escape(options[:start_at].to_s)}" if options[:start_at]
         url << "&maxResults=#{CGI.escape(options[:max_results].to_s)}" if options[:max_results]
+
+        if options[:expand]
+          options[:expand] = [options[:expand]] if options[:expand].is_a?(String)
+          url << "&expand=#{options[:expand].to_a.map{ |value| CGI.escape(value.to_s) }.join(',')}"
+        end
 
         response = client.get(url)
         json = parse_json(response.body)

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -84,6 +84,34 @@ describe JIRA::Resource::Issue do
     expect(JIRA::Resource::Issue.jql(client,'foo bar', start_at: 1, max_results: 3)).to eq([''])
   end
 
+  it "should search an issue with a jql query string and string expand" do
+    response = double()
+    issue = double()
+
+    allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
+    expect(client).to receive(:get)
+      .with('/jira/rest/api/2/search?jql=foo+bar&expand=transitions')
+      .and_return(response)
+    expect(client).to receive(:Issue).and_return(issue)
+    expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
+
+    expect(JIRA::Resource::Issue.jql(client,'foo bar', expand: 'transitions')).to eq([''])
+  end
+
+  it "should search an issue with a jql query string and array expand" do
+    response = double()
+    issue = double()
+
+    allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
+    expect(client).to receive(:get)
+      .with('/jira/rest/api/2/search?jql=foo+bar&expand=transitions')
+      .and_return(response)
+    expect(client).to receive(:Issue).and_return(issue)
+    expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
+
+    expect(JIRA::Resource::Issue.jql(client,'foo bar', expand: %w(transitions))).to eq([''])
+  end
+
   it "provides direct accessors to the fields" do
     subject = JIRA::Resource::Issue.new(client, :attrs => {'fields' => {'foo' =>'bar'}})
     expect(subject).to respond_to(:foo)


### PR DESCRIPTION
Just a small change to allow specifying expand parameters in a JQL search of issues.  