### PR TITLE
Add http timeout options

### DIFF
--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -40,6 +40,8 @@ module JIRA
       http_conn = http_class.new(uri.host, uri.port)
       http_conn.use_ssl = @options[:use_ssl]
       http_conn.verify_mode = @options[:ssl_verify_mode]
+      http_conn.open_timeout = @options[:http_open_timeout] if @options[:http_open_timeout]
+      http_conn.read_timeout = @options[:http_read_timeout] if @options[:http_read_timeout]
       http_conn
     end
 


### PR DESCRIPTION
The server side timeout of JIRA API requests seems to default to 90 sec. But the default read_timeout of Net::HTTP on client side is 60 sec. This difference made problems in our systems - client timeouts and disconnects, server continues to finish the request, client doesn't know the request was actually fulfilled.
So we needed to increase the client side timeout to be longer than the server side. That is :http_read_timeout.

Included :http_open_timeout also while I'm at it. It is for establishing the connection. Its current default is nil (indefinite), but there is an underlying TCPConnect timeout (Errno::ETIMEDOUT) which appears to be 60 or 75 sec. Some may want to decrease it.

You can omit these options if you're happy with the defaults, or you can provide these options when you initialize JIRA::Client.
