### PR TITLE
Fix missing "project" option in resource/version.rb

### DIFF
--- a/lib/jira/resource/version.rb
+++ b/lib/jira/resource/version.rb
@@ -4,7 +4,29 @@ module JIRA
     class VersionFactory < JIRA::BaseFactory # :nodoc:
     end
 
-    class Version < JIRA::Base ; end
+    class Version < JIRA::Base
+      belongs_to :project
+
+      nested_collections true
+
+      def self.endpoint_name
+        'versions'
+      end
+
+      def self.all(client, options = {})
+        project = options[:project]
+        unless project
+          raise ArgumentError.new("project is required")
+        end
+
+        path = "#{project.self}/#{endpoint_name}"
+        response = client.get(path)
+        json = parse_json(response.body)
+        json.map do |version|
+          project.versions.build(version)
+        end
+      end
+    end
 
   end
 end


### PR DESCRIPTION
The *version* resource requires a *project* argument in order to work, see [JIRA 6.4.3 REST API documentation](https://docs.atlassian.com/jira/REST/6.4.3/#d2e2344). I used [lib/jira/resource/transition.rb](https://github.com/sumoheavy/jira-ruby/blob/e0da6c51176c4972fbc8b688bd54a6090004d6b4/lib/jira/resource/transition.rb) as a template and adapted it (to make sure that I'm following your coding and formatting standards). The code is tested and works.

Thanks!