### PR TITLE
Issue #105: Now adding the prefix to the base#url method

### DIFF
--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -420,7 +420,6 @@ module JIRA
         end
       end
       if @attrs['self']
-        prefix + @attrs['self'].sub(@client.options[:site],'')
         @attrs['self'].sub(@client.options[:site],'')
       elsif key_value
         self.class.singular_path(client, key_value.to_s, prefix)

--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -348,7 +348,9 @@ module JIRA
     # JIRA::HTTPError if the request fails (response is not HTTP 2xx).
     def save!(attrs)
       http_method = new_record? ? :post : :put
-      response = client.send(http_method, url, attrs.to_json)
+      the_url = url
+      the_url = the_url.gsub(/\/\//, '/') if !the_url.nil?
+      response = client.send(http_method, the_url, attrs.to_json)
       set_attrs(attrs, false)
       set_attrs_from_response(response)
       @expanded = false
@@ -419,6 +421,7 @@ module JIRA
       end
       if @attrs['self']
         prefix + @attrs['self'].sub(@client.options[:site],'')
+        @attrs['self'].sub(@client.options[:site],'')
       elsif key_value
         self.class.singular_path(client, key_value.to_s, prefix)
       else

--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -418,7 +418,7 @@ module JIRA
         end
       end
       if @attrs['self']
-        @attrs['self'].sub(@client.options[:site],'')
+        prefix + @attrs['self'].sub(@client.options[:site],'')
       elsif key_value
         self.class.singular_path(client, key_value.to_s, prefix)
       else


### PR DESCRIPTION
such that when the 'self' attribute exists, the prefix is added to the base of the url.

This appears to have broken some integration tests (in some cases the URLs wind up with "//" instead of a single slash at the start of the url).