### PR TITLE
Issue #105: Ensuring that URLs begin with a slash "/" character

### DIFF
--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -348,7 +348,9 @@ module JIRA
     # JIRA::HTTPError if the request fails (response is not HTTP 2xx).
     def save!(attrs)
       http_method = new_record? ? :post : :put
-      response = client.send(http_method, url, attrs.to_json)
+      the_url = url
+      the_url = the_url.gsub(/\/\//, '/') if !the_url.nil?
+      response = client.send(http_method, the_url, attrs.to_json)
       set_attrs(attrs, false)
       set_attrs_from_response(response)
       @expanded = false
@@ -419,6 +421,7 @@ module JIRA
       end
       if @attrs['self']
         prefix + @attrs['self'].sub(@client.options[:site],'')
+        @attrs['self'].sub(@client.options[:site],'')
       elsif key_value
         self.class.singular_path(client, key_value.to_s, prefix)
       else

--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -418,7 +418,7 @@ module JIRA
         end
       end
       if @attrs['self']
-        @attrs['self'].sub(@client.options[:site],'')
+        prefix + @attrs['self'].sub(@client.options[:site],'')
       elsif key_value
         self.class.singular_path(client, key_value.to_s, prefix)
       else

--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -348,9 +348,7 @@ module JIRA
     # JIRA::HTTPError if the request fails (response is not HTTP 2xx).
     def save!(attrs)
       http_method = new_record? ? :post : :put
-      the_url = url
-      the_url = the_url.gsub(/\/\//, '/') if !the_url.nil?
-      response = client.send(http_method, the_url, attrs.to_json)
+      response = client.send(http_method, url, attrs.to_json)
       set_attrs(attrs, false)
       set_attrs_from_response(response)
       @expanded = false

--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -420,8 +420,9 @@ module JIRA
         end
       end
       if @attrs['self']
-        prefix + @attrs['self'].sub(@client.options[:site],'')
-        @attrs['self'].sub(@client.options[:site],'')
+        the_url = @attrs['self'].sub(@client.options[:site],'')
+        the_url = "/#{the_url}" if (the_url =~ /^\//).nil?
+        the_url
       elsif key_value
         self.class.singular_path(client, key_value.to_s, prefix)
       else


### PR DESCRIPTION
Up until this fix, I was unable to save tickets back to our JIRA environment.  We were ending up with URLs that did not start with a "/".  I've updated the code such that a leading slash is now enforced.  The specs do not break as a result of this fix either.

The configuration we were using is the following (though I've substituted our site with a dummy site name):
```
{
  :username => ENV['JIRA_USERNAME'], 
  :password => ENV['JIRA_PASSWORD'], 
  :site => "https://mycompany.atlassian.net/", 
  :context_path => "", 
  :auth_type => :basic
}
```