### PR TITLE
Added to_s to fix nil implicit converion in base.rb

### DIFF
--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -414,7 +414,7 @@ module JIRA
       prefix = '/'
       unless self.class.belongs_to_relationships.empty?
         prefix = self.class.belongs_to_relationships.inject(prefix) do |prefix_so_far, relationship|
-          prefix_so_far + relationship.to_s + "/" + self.send("#{relationship.to_s}_id") + '/'
+          prefix_so_far.to_s + relationship.to_s + "/" + self.send("#{relationship.to_s}_id").to_s + '/'
         end
       end
       if @attrs['self']


### PR DESCRIPTION
This modification should fix:
jira/base.rb:417:in `+': no implicit conversion of nil into String (TypeError)