### PR TITLE
Make issues able to have fix versions

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -29,7 +29,9 @@ module JIRA
       has_many :attachments, :nested_under => 'fields',
                           :attribute_key => 'attachment'
 
-      has_many :versions, :nested_under => 'fields'
+      has_many :versions,    :nested_under => 'fields'
+      has_many :fixVersions, :class => JIRA::Resource::Version,
+                             :nested_under => 'fields'
 
       has_many :worklogs, :nested_under => ['fields','worklog']
 


### PR DESCRIPTION
Added `has_many :fixVersions [...]` to the Issue class, so that `issue.fixVersions` consistently returns versions, just like `issue.versions`.