### PR TITLE
Added http request read timeout

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -91,7 +91,8 @@ of JIRA.
               :password => password,
               :site     => 'http://localhost:8080/',
               :context_path => '/myjira',
-              :auth_type => :basic
+              :auth_type => :basic,
+              :read_timeout => 120
             }
 
   client = JIRA::Client.new(options)

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -40,6 +40,7 @@ module JIRA
       http_conn = http_class.new(uri.host, uri.port)
       http_conn.use_ssl = @options[:use_ssl]
       http_conn.verify_mode = @options[:ssl_verify_mode]
+      http_conn.read_timeout = @options[:read_timeout]
       http_conn
     end
 

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -96,6 +96,7 @@ describe JIRA::HttpClient do
     expect(Net::HTTP).to receive(:new).with(host, port).and_return(http_conn)
     expect(http_conn).to receive(:use_ssl=).with(basic_client.options[:use_ssl]).and_return(http_conn)
     expect(http_conn).to receive(:verify_mode=).with(basic_client.options[:ssl_verify_mode]).and_return(http_conn)
+    expect(http_conn).to receive(:read_timeout=).with(basic_client.options[:read_timeout]).and_return(http_conn)
     expect(basic_client.http_conn(uri)).to eq(http_conn)
   end
 


### PR DESCRIPTION
`read_timeout` parameter can be used optionally when there is a large JIRA data set to be extracted. 