### PR TITLE
fix README rdoc syntax

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = JIRA API Gem
 {<img src="https://codeclimate.com/github/sumoheavy/jira-ruby.png" />}[https://codeclimate.com/github/sumoheavy/jira-ruby]
-{<img src="https://travis-ci.org/sumoheavy/jira-ruby.png?branch=master"}[https://travis-ci.org/sumoheavy/jira-ruby]
+{<img src="https://travis-ci.org/sumoheavy/jira-ruby.png?branch=master" />}[https://travis-ci.org/sumoheavy/jira-ruby]
 
 This gem provides access to the Atlassian JIRA REST API.
 
@@ -80,7 +80,7 @@ of JIRA.
   require 'pp'
   require 'jira'
 
-  # Consider the use of :use_ssl and :ssl_verify_mode options if running locally 
+  # Consider the use of :use_ssl and :ssl_verify_mode options if running locally
   # for tests.
 
   username = "myremoteuser"
@@ -98,7 +98,7 @@ of JIRA.
 
   # Show all projects
   projects = client.Project.all
-  
+
   projects.each do |project|
     puts "Project -> key: #{project.key}, name: #{project.name}"
   end
@@ -135,7 +135,7 @@ errors are handled gracefully
     private
 
     def get_jira_client
-      
+
       # add any extra configuration options for your instance of JIRA,
       # e.g. :use_ssl, :ssl_verify_mode, :context_path, :site
       options = {
@@ -253,7 +253,7 @@ Here's the same example as a Sinatra application:
       if !session[:jira_auth]
         # not logged in
         <<-eos
-          <h1>jira-ruby (JIRA 5 Ruby Gem) demo </h1>You're not signed in. Why don't you 
+          <h1>jira-ruby (JIRA 5 Ruby Gem) demo </h1>You're not signed in. Why don't you
           <a href=/signin>sign in</a> first.
         eos
       else
@@ -262,25 +262,25 @@ Here's the same example as a Sinatra application:
 
         # HTTP response inlined with bind data below...
         <<-eos
-          You're now signed in. There #{@issues.count == 1 ? "is" : "are"} #{@issues.count} 
+          You're now signed in. There #{@issues.count == 1 ? "is" : "are"} #{@issues.count}
           issue#{@issues.count == 1 ? "" : "s"} in this JIRA instance. <a href='/signout'>Signout</a>
         eos
       end
     end
 
     # http://<yourserver>/signin
-    # Initiates the OAuth dance by first requesting a token then redirecting to 
+    # Initiates the OAuth dance by first requesting a token then redirecting to
     # http://<yourserver>/auth to get the @access_token
     get '/signin' do
       request_token = @jira_client.request_token
       session[:request_token] = request_token.token
       session[:request_secret] = request_token.secret
 
-      redirect request_token.authorize_url    
+      redirect request_token.authorize_url
     end
 
     # http://<yourserver>/callback
-    # Retrieves the @access_token then stores it inside a session cookie. In a real app, 
+    # Retrieves the @access_token then stores it inside a session cookie. In a real app,
     # you'll want to persist the token in a datastore associated with the user.
     get "/callback/" do
       request_token = @jira_client.set_request_token(

--- a/README.rdoc
+++ b/README.rdoc
@@ -148,8 +148,8 @@ errors are handled gracefully
       # Add AccessToken if authorised previously.
       if session[:jira_auth]
         @jira_client.set_access_token(
-          session[:jira_auth][:access_token],
-          session[:jira_auth][:access_key]
+          session[:jira_auth]['access_token'],
+          session[:jira_auth]['access_key']
         )
       end
     end


### PR DESCRIPTION
The Travis CI link was overflowing into the first line of text. My text editor also auto removed some excess white space. Let me know if the white space is intentional.

Additionally, the example code didn't work for me on Rails 4.1.8 since the values in the jira_auth session were in string keys (rather than symbols) and the hash was not an indifferent access hash. I did not change the Sinatra example since I don't know how Sinatra handles its session variables but that example might need to be changed as well.