### PR TITLE
Issuemeta

### DIFF
--- a/lib/jira.rb
+++ b/lib/jira.rb
@@ -30,6 +30,7 @@ require 'jira/resource/filter'
 require 'jira/resource/field'
 require 'jira/resource/rapidview'
 require 'jira/resource/serverinfo'
+require 'jira/resource/createmeta'
 
 require 'jira/request_client'
 require 'jira/oauth_client'

--- a/lib/jira/base_factory.rb
+++ b/lib/jira/base_factory.rb
@@ -15,7 +15,7 @@ module JIRA
       # Need to do a little bit of work here as Module.const_get doesn't work
       # with nested class names, i.e. JIRA::Resource::Foo.
       #
-      # So create a method chain from the class componenets.  This code will
+      # So create a method chain from the class components.  This code will
       # unroll to:
       #   Module.const_get('JIRA').const_get('Resource').const_get('Foo')
       #
@@ -35,7 +35,7 @@ module JIRA
       end
     end
 
-    # The priciple purpose of this class is to delegate methods to the corresponding
+    # The principle purpose of this class is to delegate methods to the corresponding
     # non-factory class and automatically prepend the client argument to the argument
     # list.
     delegate_to_target_class :all, :find, :collection_path, :singular_path, :jql

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -133,6 +133,10 @@ module JIRA
       JIRA::Resource::ServerInfoFactory.new(self)
     end
 
+    def Createmeta
+      JIRA::Resource::CreatemetaFactory.new(self)
+    end
+
     def ApplicationLink
       JIRA::Resource::ApplicationLinkFactory.new(self)
     end

--- a/lib/jira/resource/createmeta.rb
+++ b/lib/jira/resource/createmeta.rb
@@ -1,0 +1,52 @@
+module JIRA
+  module Resource
+
+    class CreatemetaFactory < JIRA::BaseFactory # :nodoc:
+    end
+
+    class Createmeta < JIRA::Base
+      def self.endpoint_name
+        '/issue/createmeta'
+      end
+
+      def self.all(client, params={})
+
+        if params.has_key?(:projectKeys)
+          values = Array(params[:projectKeys]).map{|i| (i.is_a?(JIRA::Resource::Project) ? i.key : i)}
+          params[:projectKeys] = values.join(',')
+        end
+
+        if params.has_key?(:projectIds)
+          values = Array(params[:projectIds]).map{|i| (i.is_a?(JIRA::Resource::Project) ? i.id : i)}
+          params[:projectIds] = values.join(',')
+        end
+
+        if params.has_key?(:issuetypeNames)
+          values = Array(params[:issuetypeNames]).map{|i| (i.is_a?(JIRA::Resource::Issuetype) ? i.name : i)}
+          params[:issuetypeNames] = values.join(',')
+        end
+
+        if params.has_key?(:issuetypeIds)
+          values = Array(params[:issuetypeIds]).map{|i| (i.is_a?(JIRA::Resource::Issuetype) ? i.id : i)}
+          params[:issuetypeIds] = values.join(',')
+        end
+
+        create_meta_url = client.options[:rest_base_path] + self.endpoint_name
+        params = hash_to_query_string(params)
+
+        response = params.empty? ? client.get("#{create_meta_url}") : client.get("#{create_meta_url}?#{params}")
+
+        json = parse_json(response.body)
+        self.new(client, {:attrs => json['projects']})
+      end
+
+      def self.hash_to_query_string(query_params)
+        query_params.map do |k,v|
+          CGI.escape(k.to_s) + '=' + CGI.escape(v.to_s)
+        end.join('&')
+      end
+
+    end
+
+  end
+end

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -67,6 +67,14 @@ module JIRA
         end
       end
 
+      def editmeta
+        editmeta_url = client.options[:rest_base_path] + "/#{self.class.endpoint_name}/#{key}/editmeta"
+
+        response = client.get(editmeta_url)
+        json = self.class.parse_json(response.body)
+        json['fields']
+      end
+
       def respond_to?(method_name, include_all=false)
         if attrs.keys.include?('fields') && attrs['fields'].keys.include?(method_name.to_s)
           true

--- a/spec/jira/resource/createmeta_spec.rb
+++ b/spec/jira/resource/createmeta_spec.rb
@@ -1,0 +1,253 @@
+require 'spec_helper'
+
+describe JIRA::Resource::Createmeta do
+  let(:client) {
+    double(
+      'client',
+      :options => {
+        :rest_base_path => '/jira/rest/api/2'
+      }
+    )
+  }
+
+  let(:response) {
+    double(
+      'response',
+      :body => '{"expand":"projects","projects":[{"self":"http://localhost:2029/rest/api/2/project/TST"}]}'
+    )
+  }
+
+  describe 'general' do
+    it 'should query correct url without parameters' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta').and_return(response)
+      JIRA::Resource::Createmeta.all(client)
+    end
+
+    it 'should query correct url with `expand` parameter' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?expand=projects.issuetypes.fields').and_return(response)
+      JIRA::Resource::Createmeta.all(client, :expand => 'projects.issuetypes.fields')
+    end
+
+    it 'should query correct url with `foo` parameter' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?foo=bar').and_return(response)
+      JIRA::Resource::Createmeta.all(client, :foo => 'bar')
+    end
+
+  end
+
+
+  describe 'projectKeys' do
+    it 'should query correct url when only one `projectKeys` given as string' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectKeys=PROJECT_1').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectKeys => 'PROJECT_1',
+      )
+    end
+
+    it 'should query correct url when multiple `projectKeys` given as string' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectKeys=PROJECT_1%2CPROJECT_2').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectKeys => ['PROJECT_1', 'PROJECT_2'],
+      )
+    end
+
+    it 'should query correct url when only one `projectKeys` given as Project' do
+      prj = JIRA::Resource::Project.new(client)
+      allow(prj).to receive(:key).and_return('PRJ')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectKeys=PRJ').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectKeys => prj,
+      )
+    end
+
+    it 'should query correct url when multiple `projectKeys` given as Project' do
+      prj_1 = JIRA::Resource::Project.new(client)
+      allow(prj_1).to receive(:key).and_return('PRJ_1')
+      prj_2 = JIRA::Resource::Project.new(client)
+      allow(prj_2).to receive(:key).and_return('PRJ_2')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectKeys=PRJ_2%2CPRJ_1').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectKeys => [prj_2, prj_1],
+      )
+    end
+
+    it 'should query correct url when multiple `projectKeys` given as different types' do
+      prj_5 = JIRA::Resource::Project.new(client)
+      allow(prj_5).to receive(:key).and_return('PRJ_5')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectKeys=PROJECT_1%2CPRJ_5').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectKeys => ['PROJECT_1', prj_5],
+      )
+    end
+  end
+
+
+  describe 'projectIds' do
+    it 'should query correct url when only one `projectIds` given as string' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectIds=10101').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectIds => '10101',
+      )
+    end
+
+    it 'should query correct url when multiple `projectIds` given as string' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectIds=10101%2C20202').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectIds => ['10101', '20202'],
+      )
+    end
+
+    it 'should query correct url when only one `projectIds` given as Project' do
+      prj = JIRA::Resource::Project.new(client)
+      allow(prj).to receive(:id).and_return('30303')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectIds=30303').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectIds => prj,
+      )
+    end
+
+    it 'should query correct url when multiple `projectIds` given as Project' do
+      prj_1 = JIRA::Resource::Project.new(client)
+      allow(prj_1).to receive(:id).and_return('30303')
+      prj_2 = JIRA::Resource::Project.new(client)
+      allow(prj_2).to receive(:id).and_return('50505')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectIds=50505%2C30303').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectIds => [prj_2, prj_1],
+      )
+    end
+
+    it 'should query correct url when multiple `projectIds` given as different types' do
+      prj_5 = JIRA::Resource::Project.new(client)
+      allow(prj_5).to receive(:id).and_return('60606')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?projectIds=10101%2C60606').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :projectIds => ['10101', prj_5],
+      )
+    end
+  end
+
+
+  describe 'issuetypeNames' do
+    it 'should query correct url when only one `issuetypeNames` given as string' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeNames=Feature').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeNames => 'Feature',
+      )
+    end
+
+    it 'should query correct url when multiple `issuetypeNames` given as string' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeNames=Feature%2CBug').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeNames => ['Feature', 'Bug'],
+      )
+    end
+
+    it 'should query correct url when only one `issuetypeNames` given as Issuetype' do
+      issue_type = JIRA::Resource::Issuetype.new(client)
+      allow(issue_type).to receive(:name).and_return('Epic')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeNames=Epic').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeNames => issue_type,
+      )
+    end
+
+    it 'should query correct url when multiple `issuetypeNames` given as Issuetype' do
+      issue_type_1 = JIRA::Resource::Issuetype.new(client)
+      allow(issue_type_1).to receive(:name).and_return('Epic')
+      issue_type_2 = JIRA::Resource::Issuetype.new(client)
+      allow(issue_type_2).to receive(:name).and_return('Sub-Task')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeNames=Sub-Task%2CEpic').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeNames => [issue_type_2, issue_type_1],
+      )
+    end
+
+    it 'should query correct url when multiple `issuetypeNames` given as different types' do
+      issue_type = JIRA::Resource::Issuetype.new(client)
+      allow(issue_type).to receive(:name).and_return('Epic')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeNames=Feature%2CEpic').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeNames => ['Feature', issue_type],
+      )
+    end
+  end
+
+
+  describe 'issuetypeIds' do
+    it 'should query correct url when only one `issuetypeIds` given as string' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeIds=10101').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeIds => '10101',
+      )
+    end
+
+    it 'should query correct url when multiple `issuetypeIds` given as string' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeIds=10101%2C20202').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeIds => ['10101', '20202'],
+      )
+    end
+
+    it 'should query correct url when only one `issuetypeIds` given as Issuetype' do
+      issue_type = JIRA::Resource::Issuetype.new(client)
+      allow(issue_type).to receive(:id).and_return('30303')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeIds=30303').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeIds => issue_type,
+      )
+    end
+
+    it 'should query correct url when multiple `issuetypeIds` given as Issuetype' do
+      issue_type_1 = JIRA::Resource::Issuetype.new(client)
+      allow(issue_type_1).to receive(:id).and_return('30303')
+      issue_type_2 = JIRA::Resource::Issuetype.new(client)
+      allow(issue_type_2).to receive(:id).and_return('50505')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeIds=50505%2C30303').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeIds => [issue_type_2, issue_type_1],
+      )
+    end
+
+    it 'should query correct url when multiple `issuetypeIds` given as different types' do
+      issue_type = JIRA::Resource::Issuetype.new(client)
+      allow(issue_type).to receive(:id).and_return('30303')
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/issue/createmeta?issuetypeIds=10101%2C30303').and_return(response)
+      JIRA::Resource::Createmeta.all(
+        client,
+        :issuetypeIds => ['10101', issue_type],
+      )
+    end
+  end
+end

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -128,6 +128,21 @@ describe JIRA::Resource::Issue do
     expect(JIRA::Resource::Issue.jql(client,'foo bar', expand: %w(transitions))).to eq([''])
   end
 
+  it 'should return meta data available for editing an issue' do
+    subject = JIRA::Resource::Issue.new(client, :attrs => {'fields' => {'key' =>'TST=123'}})
+    response = double()
+
+    allow(response).to receive(:body).and_return(
+      '{"fields":{"summary":{"required":true,"name":"Summary","operations":["set"]}}}'
+    )
+    expect(client).to receive(:get)
+      .with('/jira/rest/api/2/issue/TST=123/editmeta')
+      .and_return(response)
+
+    expect(subject.editmeta).to eq({'summary' => {'required' => true, 'name' => 'Summary', 'operations' => ['set']}})
+  end
+
+
   it "provides direct accessors to the fields" do
     subject = JIRA::Resource::Issue.new(client, :attrs => {'fields' => {'foo' =>'bar'}})
     expect(subject).to respond_to(:foo)


### PR DESCRIPTION
Hi,
I've implemented getting meta information for Jira issues.
Now it's possible to get meta for concrete [issue](https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getEditIssueMeta) and get meta by [project and issue type](https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-discovering-meta-data-for-creating-issues).