### PR TITLE
Add an option to print the url for http requests being sent

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -37,7 +37,7 @@ module JIRA
     #
     # The authenticated client instance returned by the respective client type
     # (Oauth, Basic)
-    attr_accessor :consumer, :request_client
+    attr_accessor :consumer, :request_client, :http_debug
 
     # The configuration options for this client instance
     attr_reader :options
@@ -50,7 +50,8 @@ module JIRA
       :rest_base_path     => "/rest/api/2",
       :ssl_verify_mode    => OpenSSL::SSL::VERIFY_PEER,
       :use_ssl            => true,
-      :auth_type          => :oauth
+      :auth_type          => :oauth,
+      :http_debug         => false
     }
 
     def initialize(options={})
@@ -65,6 +66,8 @@ module JIRA
       when :basic
         @request_client = HttpClient.new(@options)
       end
+
+      @http_debug = @options[:http_debug]
 
       @options.freeze
     end
@@ -180,6 +183,7 @@ module JIRA
     # Sends the specified HTTP request to the REST API through the
     # appropriate method (oauth, basic).
     def request(http_method, path, body = '', headers={})
+      puts "#{http_method}: #{path} - [#{body}]" if @http_debug
       @request_client.request(http_method, path, body, headers)
     end
 

--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,3 +1,3 @@
 module JIRA
-  VERSION = "0.1.17"
+  VERSION = "0.1.18-pcc"
 end


### PR DESCRIPTION
This is implemented as a simple 'puts' for now.
Added an option 'http_debug' that can also be set as an option.

Optimally this should be a logger, and with to levels of logging - one for the request, and then a more verbose mode that logs the response.