### PR TITLE
Custom field handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,11 @@
 source "http://rubygems.org"
 
-gem 'pry'
-
+group :development do
+  gem 'guard'
+  gem 'guard-rspec'
+  gem 'pry'   # this was in the original Gemfile - but only needed in development
+  gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+end
+      
 # Specify your gem's dependencies in jira_api.gemspec
 gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,14 @@
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'rspec', '~> 3.0.0'
+
+guard 'rspec', cmd: 'bundle exec rspec --color --format doc' do
+  # watch /lib/ files
+  watch(%r{^lib/(.+).rb$}) do |m|
+    "spec/#{m[1]}_spec.rb"
+  end
+ 
+  # watch /spec/ files
+  watch(%r{^spec/(.+).rb$}) do |m|
+    "spec/#{m[1]}.rb"
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,11 @@ task :prepare do
 end
 
 desc 'Run RSpec tests'
-RSpec::Core::RakeTask.new(:spec)
+#RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |task|
+  task.rspec_opts = ['--color', '--format', 'doc']
+end
+
 
 Rake::RDocTask.new(:doc) do |rd|
   rd.main       = 'README.rdoc'

--- a/example.rb
+++ b/example.rb
@@ -42,6 +42,28 @@ end
 issue = client.Issue.find('SAMPLEPROJECT-1')
 pp issue
 
+# # Handling fields by name, rather than by id
+# # ------------------------------------------
+# Cache the Field list from the server
+client.Field.map_fields
+# This allows use of friendlier names for custom fields
+# Say that 'Special Field' is customfield_12345
+# It becomes mapped to Special_Field which is usable as a method call
+#
+# Say that there is a second 'Special Field' is customfield_54321
+# Names are deduplicated so the second 'Special Field' becomes Special_Field_54321
+#
+# Names are massaged to get rid of special characters, and spaces
+# So 'Special & @ Field' becomes Special_____Field - not perfect, but usable
+old_way = issue.customfield_12345
+new_way = issue.Special_Field
+(old_way == new_way) && puts 'much easier'
+#
+# Can also use this to specify fields to be returned in the response
+client.Issue.jql(a_normal_jql_search, fields:[:Special_Field])
+# Or you could always do it the old way - if you can remember the numbers...
+client.Issue.jql(a_normal_jql_search, fields:['customfield_12345'])
+
 # # Find a specific project by key
 # # ------------------------------
 # project = client.Project.find('SAMPLEPROJECT')

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'forwardable'
+require 'ostruct'
 
 module JIRA
 
@@ -37,7 +38,7 @@ module JIRA
     #
     # The authenticated client instance returned by the respective client type
     # (Oauth, Basic)
-    attr_accessor :consumer, :request_client, :http_debug
+    attr_accessor :consumer, :request_client, :http_debug, :cache
 
     # The configuration options for this client instance
     attr_reader :options
@@ -70,6 +71,8 @@ module JIRA
       @http_debug = @options[:http_debug]
 
       @options.freeze
+
+      @cache = OpenStruct.new
     end
 
     def Project # :nodoc:

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -37,7 +37,7 @@ module JIRA
     #
     # The authenticated client instance returned by the respective client type
     # (Oauth, Basic)
-    attr_accessor :consumer, :request_client
+    attr_accessor :consumer, :request_client, :http_debug
 
     # The configuration options for this client instance
     attr_reader :options
@@ -50,7 +50,8 @@ module JIRA
       :rest_base_path     => "/rest/api/2",
       :ssl_verify_mode    => OpenSSL::SSL::VERIFY_PEER,
       :use_ssl            => true,
-      :auth_type          => :oauth
+      :auth_type          => :oauth,
+      :http_debug         => false
     }
 
     def initialize(options={})
@@ -65,6 +66,8 @@ module JIRA
       when :basic
         @request_client = HttpClient.new(@options)
       end
+
+      @http_debug = @options[:http_debug]
 
       @options.freeze
     end
@@ -180,6 +183,7 @@ module JIRA
     # Sends the specified HTTP request to the REST API through the
     # appropriate method (oauth, basic).
     def request(http_method, path, body = '', headers={})
+      puts "#{http_method}: #{path} - [#{body}]" if @http_debug
       @request_client.request(http_method, path, body, headers)
     end
 

--- a/lib/jira/resource/field.rb
+++ b/lib/jira/resource/field.rb
@@ -6,23 +6,44 @@ module JIRA
     end
 
     class Field < JIRA::Base
+
+      #translate a custom field description to a method-safe name
+      def self.safe_name(description)
+        description.gsub(/[^a-zA-Z0-9]/,'_')
+      end
+
+      # safe_name plus disambiguation if it fails it uses the original jira id (customfield_#####)
+      def self.safer_name(description, jira_id)
+        "#{safe_name(description)}_#{jira_id.split('_')[1]}" rescue jira_id
+      end
+
       def self.map_fields(client)
         field_map = {}
         field_map_reverse = {}
         fields = client.Field.all
-        fields.each {|f|
+        # two pass approach, so that a custom field with the same name
+        # as a system field can't take precedence
+        fields.each do |f|
+          next if f.custom
+          name = safe_name(f.name)
+          field_map_reverse[f.id] = [f.name, name] # capture both the official name, and the mapped name
+          field_map[name] = f.id
+        end
+
+        fields.each do |f|
+          next unless f.custom
           name = if field_map.key? f.name
-            renamed = ("#{f.name}_#{f.id.split('_')[1]}").gsub(/[^a-zA-Z0-9]/,'_') rescue f.id
+            renamed = safer_name(f.name, f.id)
             warn "Duplicate Field name #{f.name} #{f.id} - renaming as #{renamed}"
             renamed
           else
-            f.name.gsub(/[^a-zA-Z0-9]/,'_')
+            safe_name(f.name)
           end
-          field_map[name] = f.id
           field_map_reverse[f.id] = [f.name, name] # capture both the official name, and the mapped name
-        }
-        client.cache.field_map = field_map
+          field_map[name] = f.id
+        end
         client.cache.field_map_reverse = field_map_reverse   # not sure where this will be used yet, but sure to be useful
+        client.cache.field_map = field_map
       end
 
       def self.field_map(client)
@@ -33,6 +54,32 @@ module JIRA
         field_name = field_name.to_s
         return field_name unless client.cache.field_map && client.cache.field_map[field_name]
         client.cache.field_map[field_name]
+      end
+
+      def respond_to?(method_name, include_all=false)
+        if [method_name.to_s, client.Field.name_to_id(method_name)].any? {|k| attrs.key?(k)}
+# "responds to either  #{method_name.to_s}  or #{client.Field.name_to_id(method_name)}"
+          true
+        else
+#warn "does parent respond to #{method_name}"
+          super(method_name)
+        end
+      end
+
+      def method_missing(method_name, *args, &block)
+          if attrs.keys.include?(method_name.to_s)
+#warn "responding to key #{method_name.to_s}"
+            attrs[method_name.to_s]
+          else
+            official_name=client.Field.name_to_id(method_name)
+#warn "responding to #{method_name} with official #{official_name}"
+            if attrs.keys.include?(official_name)
+              attrs[official_name]
+            else
+#warn "passing to parent to respond to #{method_name}"
+              super(method_name, *args, &block)
+            end
+          end
       end
     end
   end

--- a/lib/jira/resource/field.rb
+++ b/lib/jira/resource/field.rb
@@ -21,6 +21,7 @@ module JIRA
         field_map = {}
         field_map_reverse = {}
         fields = client.Field.all
+
         # two pass approach, so that a custom field with the same name
         # as a system field can't take precedence
         fields.each do |f|
@@ -42,6 +43,7 @@ module JIRA
           field_map_reverse[f.id] = [f.name, name] # capture both the official name, and the mapped name
           field_map[name] = f.id
         end
+
         client.cache.field_map_reverse = field_map_reverse   # not sure where this will be used yet, but sure to be useful
         client.cache.field_map = field_map
       end
@@ -58,25 +60,20 @@ module JIRA
 
       def respond_to?(method_name, include_all=false)
         if [method_name.to_s, client.Field.name_to_id(method_name)].any? {|k| attrs.key?(k)}
-# "responds to either  #{method_name.to_s}  or #{client.Field.name_to_id(method_name)}"
           true
         else
-#warn "does parent respond to #{method_name}"
           super(method_name)
         end
       end
 
       def method_missing(method_name, *args, &block)
           if attrs.keys.include?(method_name.to_s)
-#warn "responding to key #{method_name.to_s}"
             attrs[method_name.to_s]
           else
             official_name=client.Field.name_to_id(method_name)
-#warn "responding to #{method_name} with official #{official_name}"
             if attrs.keys.include?(official_name)
               attrs[official_name]
             else
-#warn "passing to parent to respond to #{method_name}"
               super(method_name, *args, &block)
             end
           end

--- a/lib/jira/resource/field.rb
+++ b/lib/jira/resource/field.rb
@@ -2,9 +2,38 @@ module JIRA
   module Resource
 
     class FieldFactory < JIRA::BaseFactory # :nodoc:
+       delegate_to_target_class :map_fields, :name_to_id, :field_map
     end
 
-    class Field < JIRA::Base ; end
+    class Field < JIRA::Base
+      def self.map_fields(client)
+        field_map = {}
+        field_map_reverse = {}
+        fields = client.Field.all
+        fields.each {|f|
+          name = if field_map.key? f.name
+            renamed = ("#{f.name}_#{f.id.split('_')[1]}").gsub(/[^a-zA-Z0-9]/,'_') rescue f.id
+            warn "Duplicate Field name #{f.name} #{f.id} - renaming as #{renamed}"
+            renamed
+          else
+            f.name.gsub(/[^a-zA-Z0-9]/,'_')
+          end
+          field_map[name] = f.id
+          field_map_reverse[f.id] = [f.name, name] # capture both the official name, and the mapped name
+        }
+        client.cache.field_map = field_map
+        client.cache.field_map_reverse = field_map_reverse   # not sure where this will be used yet, but sure to be useful
+      end
 
+      def self.field_map(client)
+        client.cache.field_map
+      end
+
+      def self.name_to_id(client, field_name)
+        field_name = field_name.to_s
+        return field_name unless client.cache.field_map && client.cache.field_map[field_name]
+        client.cache.field_map[field_name]
+      end
+    end
   end
 end

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -51,7 +51,7 @@ module JIRA
       def self.jql(client, jql, options = {fields: nil, start_at: nil, max_results: nil, expand: nil})
         url = client.options[:rest_base_path] + "/search?jql=" + CGI.escape(jql)
 
-        url << "&fields=#{options[:fields].map{ |value| CGI.escape(value.to_s) }.join(',')}" if options[:fields]
+        url << "&fields=#{options[:fields].map{ |value| CGI.escape(client.Field.name_to_id(value)) }.join(',')}" if options[:fields]
         url << "&startAt=#{CGI.escape(options[:start_at].to_s)}" if options[:start_at]
         url << "&maxResults=#{CGI.escape(options[:max_results].to_s)}" if options[:max_results]
 
@@ -68,7 +68,7 @@ module JIRA
       end
 
       def respond_to?(method_name, include_all=false)
-        if attrs.keys.include?('fields') && attrs['fields'].keys.include?(method_name.to_s)
+        if attrs.keys.include?('fields') && [method_name.to_s, client.Field.name_to_id(method_name)].any? {|k| attrs['fields'].key?(k)}
           true
         else
           super(method_name)
@@ -76,10 +76,19 @@ module JIRA
       end
 
       def method_missing(method_name, *args, &block)
-        if attrs.keys.include?('fields') && attrs['fields'].keys.include?(method_name.to_s)
-          attrs['fields'][method_name.to_s]
+        if attrs.keys.include?('fields')
+          if attrs['fields'].keys.include?(method_name.to_s)
+            attrs['fields'][method_name.to_s]
+          else
+            official_name=client.Field.name_to_id(method_name)
+            if attrs['fields'].keys.include?(official_name)
+              attrs['fields'][official_name]
+            else
+              super(method_name, *args, &block)
+            end
+          end
         else
-          super(method_name)
+          super(method_name, *args, &block)
         end
       end
 

--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,3 +1,3 @@
 module JIRA
-  VERSION = "0.1.17"
+  VERSION = "0.1.18-pcc"
 end

--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,3 +1,3 @@
 module JIRA
-  VERSION = "0.1.18-pcc"
+  VERSION = "0.1.18-pcc2"
 end

--- a/spec/jira/resource/field_spec.rb
+++ b/spec/jira/resource/field_spec.rb
@@ -2,23 +2,131 @@ require 'spec_helper'
 
 describe JIRA::Resource::Field do
 
+  let(:cache) { OpenStruct.new }
+
   let(:client) do
     client = double(options: {rest_base_path: '/jira/rest/api/2'}  )
-    allow(client).to receive(:Field).and_return(JIRA::Resource::FieldFactory.new(client))
-    allow(client).to receive(:cache).and_return(OpenStruct.new)
+    field = JIRA::Resource::FieldFactory.new(client)
+    allow(client).to receive(:Field).and_return(field)
+    allow(client).to receive(:cache).and_return(cache)
+    # info about all fields on the client
+    allow(client.Field).to receive(:all).and_return([
+      JIRA::Resource::Field.new(client, :attrs => {'id' =>"customfield_10666", "name" => "Priority",   "custom" => true,  "orderable" => true,  "navigable" => true, "searchable" => true,  "clauseNames" => ["cf[10666]","Priority"],         "schema" =>{"type" => "string",    "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select","customId" => 10666}}),
+      JIRA::Resource::Field.new(client, :attrs => {'id' =>"issuekey",          "name" => "Key",        "custom" => false, "orderable" => false, "navigable" => true, "searchable" => false, "clauseNames" => ["id","issue","issuekey","key"]}),
+      JIRA::Resource::Field.new(client, :attrs => {"id" =>"priority",          "name" => "Priority",   "custom" => false, "orderable" => true,  "navigable" => true, "searchable" => true,  "clauseNames" => ["priority"],                     "schema" =>{"type" => "priority",  "system" => "priority"}}),
+      JIRA::Resource::Field.new(client, :attrs => {'id' =>"summary",           "name" => "Summary",    "custom" => false, "orderable" => true,  "navigable" => true, "searchable" => true,  "clauseNames" => ["summary"],                      "schema" =>{"type" => "string",    "system" => "summary"}}),
+      JIRA::Resource::Field.new(client, :attrs => {'id' =>"issuetype",         "name" => "Issue Type", "custom" => false, "orderable" => true,  "navigable" => true, "searchable" => true,  "clauseNames" => ["issuetype","type"],             "schema" =>{"type" => "issuetype", "system" => "issuetype"}}),
+      JIRA::Resource::Field.new(client, :attrs => {'id' =>"customfield_10111", "name" => "SingleWord", "custom" => true,  "orderable" => true,  "navigable" => true, "searchable" => true,  "clauseNames" => ["cf[10111]","SingleWord"],       "schema" =>{"type" => "string",    "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select","customId" => 10111}}),
+      JIRA::Resource::Field.new(client, :attrs => {'id' =>"customfield_10222", "name" => "Multi Word", "custom" => true,  "orderable" => true,  "navigable" => true, "searchable" => true,  "clauseNames" => ["cf[10222]","Multi Word"],       "schema" =>{"type" => "string",    "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select","customId" => 10222}}),
+      JIRA::Resource::Field.new(client, :attrs => {'id' =>"customfield_10333", "name" => "Why/N@t",    "custom" => true,  "orderable" => true,  "navigable" => true, "searchable" => true,  "clauseNames" => ["cf[10333]","Why/N@t"],          "schema" =>{"type" => "string",    "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select","customId" => 10333}}),
+      JIRA::Resource::Field.new(client, :attrs => {'id' =>"customfield_10444", "name" => "SingleWord", "custom" => true,  "orderable" => true,  "navigable" => true, "searchable" => true,  "clauseNames" => ["cf[10444]","SingleWord"],       "schema" =>{"type" => "string",    "custom" => "com.atlassian.jira.plugin.system.customfieldtypes:select","customId" => 10444}})
+    ])
     client
   end
 
   describe "field_mappings" do
-    subject {
-      JIRA::Resource::Field.new(client, :attrs => {
-        'priority' => 1
-      })
-    }
 
-    it "can find a standard field" do
-      expect(subject.priority).to eq(1)
+    shared_context "mapped or not" do
+
+      subject {
+        JIRA::Resource::Field.new(client, :attrs => {
+          'priority' => 1,
+          'customfield_10111' => 'data_in_custom_field',
+          'customfield_10222' => 'multi word custom name',
+          'customfield_10333' => 'complex custom name',
+          'customfield_10444' => 'duplicated custom name',
+          'customfield_10666' => 'duplicate of a system name',
+        })
+      }
+
+      it "can find a standard field by id" do
+        expect(subject.priority).to eq(1)
+      end
+
+      it "can find a custom field by customfield_##### name" do
+        expect(subject.customfield_10111).to eq('data_in_custom_field')
+      end
+
+      it "is not confused by common attribute keys" do
+        expect{subject.name}.to raise_error(NoMethodError)
+        expect{subject.custom}.to raise_error(NoMethodError)
+        expect(subject.id).to eq(nil)   # picks up ID from the parent -
+      end
+    end
+
+    context "before fields are mapped" do
+
+      include_context "mapped or not"
+
+      it "can find a standard field by id" do
+        expect(subject.priority).to eq(1)
+      end
+
+      it "cannot find a standard field by name before mapping" do
+        expect{subject.Priority}.to raise_error(NoMethodError)
+      end
+
+      it "can find a custom field by customfield_##### name" do
+        expect(subject.customfield_10111).to eq('data_in_custom_field')
+      end
+
+      it "cannot find a mapped field before mapping and raises error" do
+        expect{subject.SingleWork}.to raise_error(NoMethodError)
+      end
+
+      it "is not confused by common attribute keys and raises error" do
+        expect{subject.name}.to raise_error(NoMethodError)
+        expect{subject.custom}.to raise_error(NoMethodError)
+        expect(subject.id).to eq(nil)   # picks up ID from the parent -
+      end
+    end
+
+    context "after fields are mapped" do
+
+      before do
+        silence_stream(STDERR) do
+          expect(client.Field.map_fields.class).to eq(Hash)
+        end
+      end
+
+      include_context "mapped or not"
+
+      it "warns of duplicate fields" do
+        expect{client.Field.map_fields}.to output(/renaming as Priority_10666/).to_stderr
+        expect{client.Field.map_fields}.to output(/renaming as SingleWord_10444/).to_stderr
+      end
+
+      it "can find a mapped field after mapping and returns results" do
+        expect{subject.SingleWord}.to_not raise_error
+        expect(subject.SingleWord).to eq subject.customfield_10111
+      end
+
+      it "handles duplicate names in a safe fashion" do
+        expect{subject.Multi_Word}.to_not raise_error
+        expect(subject.Multi_Word).to eq subject.customfield_10222
+      end
+
+      it "handles special characters in a safe fashion" do
+        expect{subject.Why_N_t}.to_not raise_error
+        expect(subject.Why_N_t).to eq subject.customfield_10333
+      end
+
+      it "handles duplicates in custom names" do
+        expect{subject.SingleWord_10444}.to_not raise_error
+        expect(subject.SingleWord_10444).to eq subject.customfield_10444
+      end
+
+      it "keeps custom names from overwriting system names" do
+        #expect(client.Field.map_fields.class).to eq(Hash)
+        expect{subject.Priority_10666}.to_not raise_error
+        expect(subject.Priority_10666).to eq subject.customfield_10666
+      end
+
+      it "can find a standard field by an expanded name" do
+        #expect(client.Field.map_fields.class).to eq(Hash)
+        expect(subject.priority).to eq(1)
+        expect(subject.Priority).to eq(1)
+      end
     end
   end
-
 end

--- a/spec/jira/resource/field_spec.rb
+++ b/spec/jira/resource/field_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe JIRA::Resource::Field do
+
+  let(:client) do
+    client = double(options: {rest_base_path: '/jira/rest/api/2'}  )
+    allow(client).to receive(:Field).and_return(JIRA::Resource::FieldFactory.new(client))
+    allow(client).to receive(:cache).and_return(OpenStruct.new)
+    client
+  end
+  
+  describe "field_mappings" do
+    subject {
+      JIRA::Resource::Field.new(client, :attrs => {
+        'priority' => 1
+      })
+    }
+
+    it "can find a standard field" do
+      expect(subject.priority).to eq(1)
+    end
+  end
+
+end

--- a/spec/jira/resource/field_spec.rb
+++ b/spec/jira/resource/field_spec.rb
@@ -8,7 +8,7 @@ describe JIRA::Resource::Field do
     allow(client).to receive(:cache).and_return(OpenStruct.new)
     client
   end
-  
+
   describe "field_mappings" do
     subject {
       JIRA::Resource::Field.new(client, :attrs => {

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -5,7 +5,12 @@ describe JIRA::Resource::Issue do
   class JIRAResourceDelegation < SimpleDelegator # :nodoc:
   end
 
-  let(:client) { double(options: {rest_base_path: '/jira/rest/api/2'}) }
+  let(:client) do
+    client = double(options: {rest_base_path: '/jira/rest/api/2'}  )
+    allow(client).to receive(:Field).and_return(JIRA::Resource::FieldFactory.new(client))
+    allow(client).to receive(:cache).and_return(OpenStruct.new)
+    client
+  end
 
   describe "#respond_to?" do
     describe "when decorated by SimpleDelegator" do


### PR DESCRIPTION
These are some changes intended to make dealing with custom fields easier.

Hopefully it fits with your intent for the project.  I think it probably fills the needs of many JIRA users, and I hope I've implemented it in a way that works for you.  I see this being extensible to other areas as well - other settings that are kept at the Jira server level (and so should be associated with the client object), rather than at a level that should be associated with the resource.  

It also includes the http_debug functionality from my earlier pull request (sorry, I should have segmented that out, but it seems very innocuous and useful). It also includes some configuration for the use of guard [you will likely want to exclude change 9ecee2e].  I'm still getting the hang of branching in github for sharing purposes...

Please let me know what you think, and if you have any questions or suggestions.  If this approach works, then I can move forward with some other ideas that build on this.

Best Regards,
Paul

Summarizing, it adds an OpenStruct cache at the client level.
Then there is a call from the Field object that can populate that cache with mapped data coming from a client.Field.all() call.
Once a user makes that call they can deal with field methods using method names based on the field name, rather than a field id.

I've added to the example.rb file, and think that summarized the usage.
```ruby
# # Handling fields by name, rather than by id
# # ------------------------------------------
# Cache the Field list from the server
client.Field.map_fields
# This allows use of friendlier names for custom fields
# Say that 'Special Field' is customfield_12345
# It becomes mapped to Special_Field which is usable as a method call
#
# Say that there is a second 'Special Field' is customfield_54321
# Names are deduplicated so the second 'Special Field' becomes Special_Field_54321
#
# Names are massaged to get rid of special characters, and spaces
# So 'Special & @ Field' becomes Special_____Field - not perfect, but usable
old_way = issue.customfield_12345
new_way = issue.Special_Field
(old_way == new_way) && puts 'much easier'
#
# Can also use this to specify fields to be returned in the response
client.Issue.jql(a_normal_jql_search, fields:[:Special_Field])
# Or you could always do it the old way - if you can remember the numbers...
client.Issue.jql(a_normal_jql_search, fields:['customfield_12345'])

