### PR TITLE
[inflector] fix the active record inflector to support plurals correctly

### DIFF
--- a/lib/jira.rb
+++ b/lib/jira.rb
@@ -2,7 +2,7 @@ $: << File.expand_path(File.dirname(__FILE__))
 
 require 'active_support/inflector'
 ActiveSupport::Inflector.inflections do |inflector|
-  inflector.singular 'status', 'status'
+  inflector.singular /status$/, 'status'
 end
 
 require 'jira/base'


### PR DESCRIPTION
Fix the inflector to use regex instead of a string. 

I tested this with a rails console and verified that it indeed kept `Status` correctly and allowed `ThingStatuses` to be converted correctly when using `classify`

<img width="380" alt="screen shot 2016-04-26 at 3 28 59 am" src="https://cloud.githubusercontent.com/assets/879170/14815234/0ca16bee-0b5f-11e6-922c-5a7245af89cd.png">

Fixes: https://github.com/sumoheavy/jira-ruby/issues/148