### PR TITLE
cookie based authentication implemented

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -66,8 +66,13 @@ module JIRA
         @consumer = @request_client.consumer
       when :basic
         @request_client = HttpClient.new(@options)
+      when :cookie
+        raise ArgumentError, 'Options: :use_cookies must be true for :cookie authorization type' if @options.key?(:use_cookies) && !@options[:use_cookies]
+        @options[:use_cookies] = true
+        @request_client = HttpClient.new(@options)
+        @request_client.make_cookie_auth_request
       else
-        raise ArgumentError, 'Options: ":auth_type" must be ":oauth" or ":basic"'
+        raise ArgumentError, 'Options: ":auth_type" must be ":oauth", ":cookie" or ":basic"'
       end
 
       @http_debug = @options[:http_debug]

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -17,6 +17,11 @@ module JIRA
       @cookies = {}
     end
 
+    def make_cookie_auth_request
+      body = { :username => @options[:username], :password => @options[:password] }.to_json
+      make_request(:post, '/rest/auth/1/session', body, {'Content-Type' => 'application/json'})
+    end
+
     def make_request(http_method, path, body='', headers={})
       request = Net::HTTP.const_get(http_method.to_s.capitalize).new(path, headers)
       request.body = body unless body.nil?


### PR DESCRIPTION
Hi! There are some cases when basic auth doesn't work(https://answers.atlassian.com/questions/203977/jira-api-basic-authentication-not-work). Cookie-based authentication(https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-cookie-based-authentication) works fine in such cases, so I propose to add such authentication to this library.