### PR TITLE
railtie: change require to jira-ruby from jira

### DIFF
--- a/lib/jira/railtie.rb
+++ b/lib/jira/railtie.rb
@@ -1,4 +1,4 @@
-require 'jira'
+require 'jira-ruby'
 require 'rails'
 
 module JIRA


### PR DESCRIPTION
In f1529f5545e38ad13bc4bc7b809035fcbe8673bb the require was changed from
jira-ruby to jira, but a corresponding change was not made to railtie,
which means that in a Rails application that wishes to use this gem, we
would fail to find the nonexistent file "jira" unless this change is
made (or a file named "jira" happens to be present, but that's an ugly
workaround).