### PR TITLE
If max_results set to 0, return count of issues instead of issues

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -62,6 +62,9 @@ module JIRA
 
         response = client.get(url)
         json = parse_json(response.body)
+        if options[:max_results] and options[:max_results] == 0
+          return json['total']
+        end
         json['issues'].map do |issue|
           client.Issue.build(issue)
         end

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -105,6 +105,18 @@ describe JIRA::Resource::Issue do
     expect(JIRA::Resource::Issue.jql(client,'foo bar', start_at: 1, max_results: 3)).to eq([''])
   end
 
+  it "should search an issue with a jql query string and maxResults equals zero and should return the count of tickets" do
+    response = double()
+    issue = double()
+
+    allow(response).to receive(:body).and_return('{"total": 1, "issues": []}')
+    expect(client).to receive(:get)
+      .with('/jira/rest/api/2/search?jql=foo+bar&maxResults=0')
+      .and_return(response)
+
+    expect(JIRA::Resource::Issue.jql(client,'foo bar', max_results: 0)).to eq(1)
+  end
+
   it "should search an issue with a jql query string and string expand" do
     response = double()
     issue = double()


### PR DESCRIPTION
Added a use case when Max_Results = 0.
It returns the count of issues and not an array of issues (which should be empty).

People use Max_Results = 0 to only get the count of the issues and not the datas of the issues.

Added one test for it.