### PR TITLE
validate_query: false for jql

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -48,12 +48,13 @@ module JIRA
         end
       end
 
-      def self.jql(client, jql, options = {fields: nil, start_at: nil, max_results: nil, expand: nil})
-        url = client.options[:rest_base_path] + "/search?jql=" + CGI.escape(jql)
+      def self.jql(client, jql, options = {fields: nil, start_at: nil, max_results: nil, expand: nil, validate_query: true})
+        url = client.options[:rest_base_path] + "/search?jql=#{CGI.escape(jql)}"
 
         url << "&fields=#{options[:fields].map{ |value| CGI.escape(client.Field.name_to_id(value)) }.join(',')}" if options[:fields]
         url << "&startAt=#{CGI.escape(options[:start_at].to_s)}" if options[:start_at]
         url << "&maxResults=#{CGI.escape(options[:max_results].to_s)}" if options[:max_results]
+        url << "&validateQuery=false" if options[:validate_query] === false
 
         if options[:expand]
           options[:expand] = [options[:expand]] if options[:expand].is_a?(String)


### PR DESCRIPTION
Such a great gem! Rare case of truly clever implementation. Special thanx for Field.map_fields 👍 
Allows to write code for getting JIRA API data in seconds

Here is my modest contribution - to solve issue of this kind:

```
/rest/api/2/search?jql=%28City_Australia+%3D+Berlin%29+City_Germany+%3D+Berlin
D, [2016-10-13T11:48:58.085781 #5377] DEBUG -- : [httplog] Status: 400
D, [2016-10-13T11:48:58.087346 #5377] DEBUG -- : [httplog] Response:
{"errorMessages":["The option 'Berlin' for field 'City_Australia' does not exist."],"errors":{}}
rake aborted!
JIRA::HTTPError: Bad Request
```
