### PR TITLE
Issue #107: Incorrect query params appended

### DIFF
--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -494,11 +494,9 @@ module JIRA
     end
 
     def url_with_query_params(url, query_params)
-      if not query_params.empty?
-        "#{url}?#{hash_to_query_string query_params}"
-      else
-        url
-      end
+      uri = URI.parse(url)
+      uri.query = uri.query.nil? ? "#{hash_to_query_string query_params}" : "#{uri.query}&#{hash_to_query_string query_params}" unless query_params.empty?
+      uri.to_s
     end
 
     def hash_to_query_string(query_params)


### PR DESCRIPTION
#107: When trying to expand User resource, it fails because url_with_query_params method in JIRA::Base class doesn't take into account that the url parameter passed already has query params.
