### PR TITLE
Paginate JIRA::Resource::Project#users

### DIFF
--- a/lib/jira/resource/project.rb
+++ b/lib/jira/resource/project.rb
@@ -27,9 +27,11 @@ module JIRA
         end
       end
 
-      def users
+      def users(start_at: nil, max_results: nil)
         users_url = client.options[:rest_base_path] + '/user/assignable/search'
-        query_params = {:project => self.key_value}
+        query_params = { project: self.key_value }
+        query_params['startAt'] = start_at if start_at
+        query_params['maxResults'] = max_results if max_results
         response = client.get(url_with_query_params(users_url, query_params))
         json = self.class.parse_json(response.body)
         json.map do |jira_user|

--- a/spec/jira/resource/project_spec.rb
+++ b/spec/jira/resource/project_spec.rb
@@ -67,4 +67,57 @@ describe JIRA::Resource::Project do
       end
     end
   end
+
+  describe 'users' do
+    let(:project) { JIRA::Resource::Project.new(client, attrs: { 'key' => project_key }) }
+    let(:project_key) { SecureRandom.hex }
+    let(:response) { double('response', body: '[{}]') }
+
+    context 'pagination' do
+      before(:each) do
+        user_factory = double('user factory')
+        expect(client).to receive(:User).and_return(user_factory)
+        expect(user_factory).to receive(:build).with(any_args)
+      end
+
+      it 'doesn\'t use pagination parameters by default' do
+        expect(client).to receive(:get)
+          .with("/jira/rest/api/2/user/assignable/search?project=#{project_key}")
+          .and_return(response)
+
+        project.users
+      end
+
+      it 'accepts start_at option' do
+        start_at = rand(1000)
+
+        expect(client).to receive(:get)
+          .with("/jira/rest/api/2/user/assignable/search?project=#{project_key}&startAt=#{start_at}")
+          .and_return(response)
+
+        project.users(start_at: start_at)
+      end
+
+      it 'accepts max_results option' do
+        max_results = rand(1000)
+
+        expect(client).to receive(:get)
+          .with("/jira/rest/api/2/user/assignable/search?project=#{project_key}&maxResults=#{max_results}")
+          .and_return(response)
+
+        project.users(max_results: max_results)
+      end
+
+      it 'accepts start_at and max_results options' do
+        start_at = rand(1000)
+        max_results = rand(1000)
+
+        expect(client).to receive(:get)
+          .with("/jira/rest/api/2/user/assignable/search?project=#{project_key}&startAt=#{start_at}&maxResults=#{max_results}")
+          .and_return(response)
+
+        project.users(start_at: start_at, max_results: max_results)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In order to retrieve more than the 50 first users

REST documentation: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-findAssignableUsers

Please let me know what you may need more in order to have this feature as part of the gem.