### PR TITLE
Issue #223: Add attachment meta

### DIFF
--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -6,7 +6,11 @@ module JIRA
 
     class Attachment < JIRA::Base
       has_one :author, :class => JIRA::Resource::User
-    end
 
+      def self.meta(client)
+        response = client.get(client.options[:rest_base_path] + '/attachment/meta')
+        parse_json(response.body)
+      end
+    end
   end
 end

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -2,7 +2,14 @@ require 'spec_helper'
 
 describe JIRA::Resource::Attachment do
 
-  let(:client) { double() }
+  let(:client) {
+    double(
+      'client',
+      :options => {
+        :rest_base_path => '/jira/rest/api/2'
+      }
+    )
+  }
 
   describe "relationships" do
     subject {
@@ -17,4 +24,17 @@ describe JIRA::Resource::Attachment do
     end
   end
 
+  describe '#meta' do
+    let(:response) {
+      double(
+        'response',
+        :body => '{"enabled":true,"uploadLimit":10485760}'
+      )
+    }
+
+    it 'returns meta information about attachment upload' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/attachment/meta').and_return(response)
+      JIRA::Resource::Attachment.meta(client)
+    end
+  end
 end


### PR DESCRIPTION
Use `Attachment.meta(client)` to fetch meta info i.e. uploadLimit