### PR TITLE
Fix code to continue to support Ruby 1.9.3

### DIFF
--- a/lib/jira/resource/project.rb
+++ b/lib/jira/resource/project.rb
@@ -27,11 +27,11 @@ module JIRA
         end
       end
 
-      def users(start_at: nil, max_results: nil)
+      def users(options={})
         users_url = client.options[:rest_base_path] + '/user/assignable/search'
         query_params = { project: self.key_value }
-        query_params['startAt'] = start_at if start_at
-        query_params['maxResults'] = max_results if max_results
+        query_params['startAt'] = options[:start_at] if options[:start_at]
+        query_params['maxResults'] = options[:max_results] if options[:max_results]
         response = client.get(url_with_query_params(users_url, query_params))
         json = self.class.parse_json(response.body)
         json.map do |jira_user|

--- a/spec/jira/resource/project_spec.rb
+++ b/spec/jira/resource/project_spec.rb
@@ -95,7 +95,7 @@ describe JIRA::Resource::Project do
           .with("/jira/rest/api/2/user/assignable/search?project=#{project_key}&startAt=#{start_at}")
           .and_return(response)
 
-        project.users(start_at: start_at)
+        project.users({start_at: start_at})
       end
 
       it 'accepts max_results option' do
@@ -105,7 +105,7 @@ describe JIRA::Resource::Project do
           .with("/jira/rest/api/2/user/assignable/search?project=#{project_key}&maxResults=#{max_results}")
           .and_return(response)
 
-        project.users(max_results: max_results)
+        project.users({max_results: max_results})
       end
 
       it 'accepts start_at and max_results options' do
@@ -116,7 +116,7 @@ describe JIRA::Resource::Project do
           .with("/jira/rest/api/2/user/assignable/search?project=#{project_key}&startAt=#{start_at}&maxResults=#{max_results}")
           .and_return(response)
 
-        project.users(start_at: start_at, max_results: max_results)
+        project.users({start_at: start_at, max_results: max_results})
       end
     end
   end


### PR DESCRIPTION
A _recent_ change broke Ruby 1.9.3 support due to its use of keyword arguments in a method.