### PR TITLE
Correct site URL format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ require 'jira-ruby'
 options = {
   :username     => 'username',
   :password     => 'pass1234',
-  :site         => 'http://mydomain.atlassian.net:443/',
+  :site         => 'https://mydomain.atlassian.net/',
   :context_path => '',
   :auth_type    => :basic
 }


### PR DESCRIPTION
If you specify the port in the URL, JIRA::Base#url can't be derived properly.