### PR TITLE
Iss 238 cookie improvements

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -44,7 +44,7 @@ module JIRA
     # The configuration options for this client instance
     attr_reader :options
 
-    def_delegators :@request_client, :init_access_token, :set_access_token, :set_request_token, :request_token, :access_token
+    def_delegators :@request_client, :init_access_token, :set_access_token, :set_request_token, :request_token, :access_token, :authenticated?
 
     DEFAULT_OPTIONS = {
       :site               => 'http://localhost:2990',
@@ -72,6 +72,8 @@ module JIRA
         @options[:use_cookies] = true
         @request_client = HttpClient.new(@options)
         @request_client.make_cookie_auth_request
+        @options.delete(:username)
+        @options.delete(:password)
       else
         raise ArgumentError, 'Options: ":auth_type" must be ":oauth", ":cookie" or ":basic"'
       end

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -19,7 +19,7 @@ module JIRA
 
     def make_cookie_auth_request
       body = { :username => @options[:username], :password => @options[:password] }.to_json
-      make_request(:post, '/rest/auth/1/session', body, {'Content-Type' => 'application/json'})
+      make_request(:post, @options[:context_path] + '/rest/auth/1/session', body, {'Content-Type' => 'application/json'})
     end
 
     def make_request(http_method, path, body='', headers={})

--- a/lib/jira/oauth_client.rb
+++ b/lib/jira/oauth_client.rb
@@ -62,6 +62,8 @@ module JIRA
     # Sets the access token from a preexisting token and secret.
     def set_access_token(token, secret)
       @access_token = OAuth::AccessToken.new(@consumer, token, secret)
+      @authenticated = true
+      @access_token
     end
 
     # Returns the current access token. Raises an
@@ -78,7 +80,12 @@ module JIRA
       when :post, :put
         response = access_token.send http_method, path, body, headers
       end
+      @authenticated = true
       response
+    end
+
+    def authenticated?
+      @authenticated
     end
   end
 end

--- a/spec/jira/client_spec.rb
+++ b/spec/jira/client_spec.rb
@@ -1,223 +1,209 @@
 require 'spec_helper'
 
-describe JIRA::Client do
-  before(:each) do
-    stub_request(:post, "https://foo:bar@localhost:2990/jira/rest/auth/1/session").
-      to_return(:status => 200, :body => "", :headers => {})
+# We have three forms of authentication with two clases to represent the client for those different authentications.
+# Some behaviours are shared across all three types of authentication.  these are captured here.
+RSpec.shared_examples 'Client Common Tests' do
+  it { is_expected.to be_a JIRA::Client }
+
+  it 'freezes the options once initialised' do
+    expect(subject.options).to be_frozen
   end
 
-  let(:oauth_client) do
-    JIRA::Client.new({ :consumer_key => 'foo', :consumer_secret => 'bar' })
-  end
-
-  let(:basic_client) do
-    JIRA::Client.new({ :username => 'foo', :password => 'bar', :auth_type => :basic })
-  end
-
-  let(:cookie_client) do
-    JIRA::Client.new({ :username => 'foo', :password => 'bar', :auth_type => :cookie })
-  end
-
-  let(:clients) { [oauth_client, basic_client, cookie_client] }
-
-  let(:response) do
-    response = double("response")
-    allow(response).to receive(:kind_of?).with(Net::HTTPSuccess).and_return(true)
-    response
-  end
-
-  let(:headers) { {'Accept' => 'application/json'} }
-  let(:content_type_header) { {'Content-Type' => 'application/json'} }
-  let(:merged_headers) { headers.merge(content_type_header) }
-
-  it "creates an instance" do
-    clients.each {|client| expect(client.class).to eq(JIRA::Client) }
-  end
-
-  it "allows the overriding of some options" do
-    client = JIRA::Client.new({:consumer_key => 'foo', :consumer_secret => 'bar', :site => 'http://foo.com/'})
-    expect(client.options[:site]).to eq('http://foo.com/')
-    expect(JIRA::Client::DEFAULT_OPTIONS[:site]).not_to eq('http://foo.com/')
-  end
-
-  it "prepends the context path to the rest base path" do
+  it 'prepends context path to rest base_path' do
     options = [:rest_base_path]
     defaults = JIRA::Client::DEFAULT_OPTIONS
-    options.each do |key|
-      clients.each { |client| expect(client.options[key]).to eq(defaults[:context_path] + defaults[key]) }
-    end
+    options.each { |key| expect(subject.options[key]).to eq(defaults[:context_path] + defaults[key]) }
   end
 
-  # To avoid having to validate options after initialisation, e.g. setting
-  # client.options[:invalid] = 'foo'
-  it "freezes the options" do
-    clients.each { |client| expect(client.options).to be_frozen }
+  it 'merges headers' do
+    expect(subject.send(:merge_default_headers, {})).to eq({'Accept' => 'application/json'})
   end
 
-  it "merges headers" do
-    clients.each { |client| expect(client.send(:merge_default_headers, {})).to eq({'Accept' => 'application/json'}) }
-  end
-
-  describe "creates instances of request clients" do
-    specify "that are of the correct class" do
-      expect(oauth_client.request_client.class).to eq(JIRA::OauthClient)
-      expect(basic_client.request_client.class).to eq(JIRA::HttpClient)
-      expect(cookie_client.request_client.class).to eq(JIRA::HttpClient)
-    end
-
-    specify "which have a corresponding auth type option" do
-      expect(oauth_client.options[:auth_type]).to eq(:oauth)
-      expect(basic_client.options[:auth_type]).to eq(:basic)
-      expect(cookie_client.options[:auth_type]).to eq(:cookie)
-    end
-
-    describe "like oauth" do
-
-      it "allows setting an access token" do
-        token = double()
-        expect(OAuth::AccessToken).to receive(:new).with(oauth_client.consumer, 'foo', 'bar').and_return(token)
-        access_token = oauth_client.set_access_token('foo', 'bar')
-
-        expect(access_token).to eq(token)
-        expect(oauth_client.access_token).to eq(token)
-      end
-
-      it "allows initializing the access token" do
-        request_token = OAuth::RequestToken.new(oauth_client.consumer)
-        allow(oauth_client.consumer).to receive(:get_request_token).and_return(request_token)
-        mock_access_token = double()
-        expect(request_token).to receive(:get_access_token).with(:oauth_verifier => 'abc123').and_return(mock_access_token)
-        oauth_client.init_access_token(:oauth_verifier => 'abc123')
-        expect(oauth_client.access_token).to eq(mock_access_token)
-      end
-
-      specify "that has specific default options" do
-        options = [:signature_method, :private_key_file]
-        options.each do |key|
-          expect(oauth_client.options[key]).to eq(JIRA::Client::DEFAULT_OPTIONS[key])
-        end
-      end
-    end
-
-    describe "like basic http" do
-      it "sets the username and password" do
-        expect(basic_client.options[:username]).to eq('foo')
-        expect(basic_client.options[:password]).to eq('bar')
-
-        expect(cookie_client.options[:username]).to eq('foo')
-        expect(cookie_client.options[:password]).to eq('bar')
-      end
-    end
-
-  end
-
-  describe "has http methods" do
-    before do
-      oauth_client.set_access_token("foo", "bar")
-    end
-
-    specify "that merge default headers" do
+  describe 'http methods' do
+    it 'merges default headers' do
       # stubbed response for generic client request method
-      expect(oauth_client).to receive(:request).exactly(5).times.and_return(response)
-      expect(basic_client).to receive(:request).exactly(5).times.and_return(response)
-      expect(cookie_client).to receive(:request).exactly(5).times.and_return(response)
+      expect(subject).to receive(:request).exactly(5).times.and_return(successful_response)
 
       # response for merging headers for http methods with no body
-      expect(oauth_client).to receive(:merge_default_headers).exactly(3).times.with({})
-      expect(basic_client).to receive(:merge_default_headers).exactly(3).times.with({})
-      expect(cookie_client).to receive(:merge_default_headers).exactly(3).times.with({})
+      expect(subject).to receive(:merge_default_headers).exactly(3).times.with({})
 
       # response for merging headers for http methods with body
-      expect(oauth_client).to receive(:merge_default_headers).exactly(2).times.with(content_type_header)
-      expect(basic_client).to receive(:merge_default_headers).exactly(2).times.with(content_type_header)
-      expect(cookie_client).to receive(:merge_default_headers).exactly(2).times.with(content_type_header)
+      expect(subject).to receive(:merge_default_headers).exactly(2).times.with(content_type_header)
 
+      [:delete, :get, :head].each { |method| subject.send(method, '/path', {}) }
+      [:post, :put].each {|method| subject.send(method, '/path', '', content_type_header)}
+    end
+
+    it 'calls the generic request method' do
       [:delete, :get, :head].each do |method|
-        oauth_client.send(method, '/path', {})
-        basic_client.send(method, '/path', {})
-        cookie_client.send(method, '/path', {})
+        expect(subject).to receive(:request).with(method, '/path', nil, headers).and_return(successful_response)
+        subject.send(method, '/path', {})
       end
 
       [:post, :put].each do |method|
-        oauth_client.send(method, '/path', '', content_type_header)
-        basic_client.send(method, '/path', '', content_type_header)
-        cookie_client.send(method, '/path', '', content_type_header)
-      end
-    end
-
-    specify "that call the generic request method" do
-      [:delete, :get, :head].each do |method|
-        expect(oauth_client).to receive(:request).with(method, '/path', nil, headers).and_return(response)
-        expect(basic_client).to receive(:request).with(method, '/path', nil, headers).and_return(response)
-        expect(cookie_client).to receive(:request).with(method, '/path', nil, headers).and_return(response)
-        oauth_client.send(method, '/path', {})
-        basic_client.send(method, '/path', {})
-        cookie_client.send(method, '/path', {})
-      end
-
-      [:post, :put].each do |method|
-        expect(oauth_client).to receive(:request).with(method, '/path', '', merged_headers)
-        expect(basic_client).to receive(:request).with(method, '/path', '', merged_headers)
-        expect(cookie_client).to receive(:request).with(method, '/path', '', merged_headers)
-        oauth_client.send(method, '/path', '', {})
-        basic_client.send(method, '/path', '', {})
-        cookie_client.send(method, '/path', '', {})
-      end
-    end
-
-    describe "that call a oauth client" do
-      specify "which makes a request" do
-        [:delete, :get, :head].each do |method|
-          expect(oauth_client.request_client).to receive(:make_request).with(method, '/path', nil, headers).and_return(response)
-          oauth_client.send(method, '/path', {})
-        end
-        [:post, :put].each do |method|
-          expect(oauth_client.request_client).to receive(:make_request).with(method, '/path', '', merged_headers).and_return(response)
-          oauth_client.send(method, '/path', '', {})
-        end
-      end
-    end
-
-    describe "that call a http client" do
-      it "which makes a request" do
-        [:delete, :get, :head].each do |method|
-          expect(basic_client.request_client).to receive(:make_request).with(method, '/path', nil, headers).and_return(response)
-          basic_client.send(method, '/path', headers)
-
-          expect(cookie_client.request_client).to receive(:make_request).with(method, '/path', nil, headers).and_return(response)
-          cookie_client.send(method, '/path', headers)
-        end
-        [:post, :put].each do |method|
-          expect(basic_client.request_client).to receive(:make_request).with(method, '/path', '', merged_headers).and_return(response)
-          basic_client.send(method, '/path', '', headers)
-
-          expect(cookie_client.request_client).to receive(:make_request).with(method, '/path', '', merged_headers).and_return(response)
-          cookie_client.send(method, '/path', '', headers)
-        end
+        expect(subject).to receive(:request).with(method, '/path', '', merged_headers)
+        subject.send(method, '/path', '', {})
       end
     end
   end
 
-  describe "Resource Factories" do
-    it "gets all projects" do
-      expect(JIRA::Resource::Project).to receive(:all).with(oauth_client).and_return([])
-      expect(JIRA::Resource::Project).to receive(:all).with(basic_client).and_return([])
-      expect(JIRA::Resource::Project).to receive(:all).with(cookie_client).and_return([])
-
-      expect(oauth_client.Project.all).to eq([])
-      expect(basic_client.Project.all).to eq([])
-      expect(cookie_client.Project.all).to eq([])
+  describe 'Resource Factories' do
+    it 'gets all projects' do
+      expect(JIRA::Resource::Project).to receive(:all).with(subject).and_return([])
+      expect(subject.Project.all).to eq([])
     end
 
-    it "finds a single project" do
-      find_result = double()
-      expect(JIRA::Resource::Project).to receive(:find).with(oauth_client, '123').and_return(find_result)
-      expect(JIRA::Resource::Project).to receive(:find).with(basic_client, '123').and_return(find_result)
-      expect(JIRA::Resource::Project).to receive(:find).with(cookie_client, '123').and_return(find_result)
-
-      expect(oauth_client.Project.find('123')).to eq(find_result)
-      expect(basic_client.Project.find('123')).to eq(find_result)
-      expect(cookie_client.Project.find('123')).to eq(find_result)
+    it 'finds a single project' do
+      find_result = double
+      expect(JIRA::Resource::Project).to receive(:find).with(subject, '123').and_return(find_result)
+      expect(subject.Project.find('123')).to eq(find_result)
     end
   end
 end
+
+RSpec.shared_examples 'HttpClient tests' do
+  it 'makes a valid request' do
+    [:delete, :get, :head].each do |method|
+      expect(subject.request_client).to receive(:make_request).with(method, '/path', nil, headers).and_return(successful_response)
+      subject.send(method, '/path', headers)
+    end
+    [:post, :put].each do |method|
+      expect(subject.request_client).to receive(:make_request).with(method, '/path', '', merged_headers).and_return(successful_response)
+      subject.send(method, '/path', '', headers)
+    end
+  end
+end
+
+describe JIRA::Client do
+  let(:request) { subject.request_client.class }
+  let(:successful_response) do
+    response = double('response')
+    allow(response).to receive(:kind_of?).with(Net::HTTPSuccess).and_return(true)
+    response
+  end
+  let(:content_type_header) { {'Content-Type' => 'application/json'} }
+  let(:headers) { {'Accept' => 'application/json'} }
+  let(:merged_headers) { headers.merge(content_type_header) }
+
+  context 'behaviour that applies to all client classes irrespective of authentication method' do
+    it 'allows the overriding of some options' do
+      client = JIRA::Client.new({:consumer_key => 'foo', :consumer_secret => 'bar', :site => 'http://foo.com/'})
+      expect(client.options[:site]).to eq('http://foo.com/')
+      expect(JIRA::Client::DEFAULT_OPTIONS[:site]).not_to eq('http://foo.com/')
+    end
+  end
+
+  context 'with basic http authentication' do
+    subject { JIRA::Client.new(username: 'foo', password: 'bar', auth_type: :basic) }
+
+    before(:each) do
+      stub_request(:get, 'https://foo:bar@localhost:2990/jira/rest/api/2/project')
+        .to_return(status: 200, body: '[]', headers: {} )
+
+      stub_request(:get, 'https://foo:badpassword@localhost:2990/jira/rest/api/2/project').
+        to_return(status: 401, headers: {} )
+    end
+
+    include_examples 'Client Common Tests'
+
+    specify { expect(subject.request_client).to be_a JIRA::HttpClient }
+
+    it 'sets the username and password' do
+      expect(subject.options[:username]).to eq('foo')
+      expect(subject.options[:password]).to eq('bar')
+    end
+
+    it 'fails with wrong user name and password' do
+      bad_login = JIRA::Client.new(username: 'foo', password: 'badpassword', auth_type: :basic)
+      expect{bad_login.Project.all}.to raise_error JIRA::HTTPError
+    end
+  end
+
+  context 'with cookie authentication' do
+    subject { JIRA::Client.new(username: 'foo', password: 'bar', auth_type: :cookie) }
+
+    let(:session_cookie) { '6E3487971234567896704A9EB4AE501F' }
+    let(:session_body) do
+      {
+        'session': {'name' => "JSESSIONID", 'value' => session_cookie },
+        'loginInfo': {'failedLoginCount' => 1, 'loginCount' => 2,
+                      'lastFailedLoginTime' => (DateTime.now - 2).iso8601,
+                      'previousLoginTime' => (DateTime.now - 5).iso8601 }
+      }
+    end
+
+    before(:each) do
+      # General case of API call with no authentication, or wrong authentication
+      stub_request(:post, 'https://localhost:2990/jira/rest/auth/1/session').
+        to_return(status: 401, headers: {} )
+
+      # Now special case of API with correct authentication.  This gets checked first by RSpec.
+      stub_request(:post, 'https://localhost:2990/jira/rest/auth/1/session')
+        .with(body: '{"username":"foo","password":"bar"}')
+        .to_return(status: 200, body: session_body.to_json,
+                   headers: { 'Set-Cookie': "JSESSIONID=#{session_cookie}; Path=/; HttpOnly"})
+
+      stub_request(:get, 'https://localhost:2990/jira/rest/api/2/project')
+        .with(headers: { cookie: "JSESSIONID=#{session_cookie}" } )
+        .to_return(status: 200, body: '[]', headers: {} )
+    end
+
+    include_examples 'Client Common Tests'
+
+    specify { expect(subject.request_client).to be_a JIRA::HttpClient }
+
+    it 'authenticates with a correct username and password' do
+      expect(subject.Project.all).to be_empty
+    end
+
+    it 'does not authenticate with an incorrect username and password' do
+      bad_client = JIRA::Client.new(username: 'foo', password: 'bad_password', auth_type: :cookie)
+    end
+  end
+
+  context 'oath2 authentication' do
+    subject { JIRA::Client.new(consumer_key: 'foo', consumer_secret: 'bar') }
+
+    include_examples 'Client Common Tests'
+
+    specify { expect(subject.request_client).to be_a JIRA::OauthClient }
+
+    it 'allows setting an access token' do
+      token = double
+      expect(OAuth::AccessToken).to receive(:new).with(subject.consumer, 'foo', 'bar').and_return(token)
+      access_token = subject.set_access_token('foo', 'bar')
+
+      expect(access_token).to eq(token)
+      expect(subject.access_token).to eq(token)
+    end
+
+    it 'allows initializing the access token' do
+      request_token = OAuth::RequestToken.new(subject.consumer)
+      allow(subject.consumer).to receive(:get_request_token).and_return(request_token)
+      mock_access_token = double
+      expect(request_token).to receive(:get_access_token).with(:oauth_verifier => 'abc123').and_return(mock_access_token)
+      subject.init_access_token(:oauth_verifier => 'abc123')
+      expect(subject.access_token).to eq(mock_access_token)
+    end
+
+    specify 'that has specific default options' do
+      [:signature_method, :private_key_file].each do |key|
+        expect(subject.options[key]).to eq(JIRA::Client::DEFAULT_OPTIONS[key])
+      end
+    end
+
+    describe 'that call a oauth client' do
+      specify 'which makes a request' do
+        [:delete, :get, :head].each do |method|
+          expect(subject.request_client).to receive(:make_request).with(method, '/path', nil, headers).and_return(successful_response)
+          subject.send(method, '/path', {})
+        end
+        [:post, :put].each do |method|
+          expect(subject.request_client).to receive(:make_request).with(method, '/path', '', merged_headers).and_return(successful_response)
+          subject.send(method, '/path', '', {})
+        end
+      end
+    end
+  end
+end
+

--- a/spec/jira/client_spec.rb
+++ b/spec/jira/client_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe JIRA::Client do
   before(:each) do
-    stub_request(:post, "https://foo:bar@localhost:2990/rest/auth/1/session").
+    stub_request(:post, "https://foo:bar@localhost:2990/jira/rest/auth/1/session").
       to_return(:status => 200, :body => "", :headers => {})
   end
 

--- a/spec/jira/client_spec.rb
+++ b/spec/jira/client_spec.rb
@@ -105,6 +105,7 @@ describe JIRA::Client do
     end
 
     include_examples 'Client Common Tests'
+    include_examples 'HttpClient tests'
 
     specify { expect(subject.request_client).to be_a JIRA::HttpClient }
 
@@ -157,6 +158,7 @@ describe JIRA::Client do
     end
 
     include_examples 'Client Common Tests'
+    include_examples 'HttpClient tests'
 
     specify { expect(subject.request_client).to be_a JIRA::HttpClient }
 

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -44,7 +44,7 @@ describe JIRA::HttpClient do
     expect(basic_client.basic_auth_http_conn.class).to eq(Net::HTTP)
   end
 
-  xit "makes a correct HTTP request for make_cookie_auth_request" do
+  it "makes a correct HTTP request for make_cookie_auth_request" do
     request = double()
     basic_auth_http_conn = double()
 


### PR DESCRIPTION
This pull request has two parts to it.  Note, two changes from my previous pull request are also included in this PR.

# Part 1: changes suggested under #238

I have added an `authenticated?` method to the `JIRA::Client` class.  This can be used to check if the user has been authenticated against JIRA.

Also, for cookie authentication I delete the username and password from `client` and `http_client` so that this information does not persist in the application.  This is done as soon as we have received the cookie from JIRA.

For basic authentication, when the client has been created, `authenticated?` will initially return false, since creating the client does not actually involve any calls to the JIRA API.  Once a successful API call has been made `authenticated?` will return true.

I have also added an `authenticated?` to the `OAuthClient` class which should behave the same.  I don't use OAuth so its a bit harder to know if I have got it right.

# Part 2: Refactor client_spec.rb

As I was developing this, I found adding suitable specs to `client_spec.rb` difficult as it was not always clear where to add them.  I was also finding that because of its structure, the new specs were looking messy within the old structure.  I therefore decided to refactor `client_spec.rb` to bring it more inline with the current way of doing things in RSpec.

This means two fairly substantial changes.  Firstly, I have adopted the use of the `subject` mechanism throughout the specs.  Secondly, rather than have a list `[basic_client, cookie_client, oauth_client]` where we iterate over the tests, I have made heavy use of shared examples.  Likewise, where the same test was often repeated in almost identical ways on three lines, have also moved these to the shared examples.  IMHO it makes it easier to read the tests.  It also makes it easier to understand which tests have failed if they fail.

Unfortunately, GIT doesn't do a great job of showing the changes.  All existing tests are still there.  However, in some cases there position has changed.  Also many lines have changed because of the use of `subject.`  Long winded way of saying, look at the file in its current state rather than the diff.
