### PR TITLE
Add agile/1.0/board/{boardId}/issue

### DIFF
--- a/lib/jira/base_factory.rb
+++ b/lib/jira/base_factory.rb
@@ -38,7 +38,7 @@ module JIRA
     # The principle purpose of this class is to delegate methods to the corresponding
     # non-factory class and automatically prepend the client argument to the argument
     # list.
-    delegate_to_target_class :all, :find, :collection_path, :singular_path, :jql, :get_backlog_issues, :get_sprints, :get_sprint_issues, :get_projects, :get_projects_full
+    delegate_to_target_class :all, :find, :collection_path, :singular_path, :jql, :get_backlog_issues, :get_board_issues, :get_sprints, :get_sprint_issues, :get_projects, :get_projects_full
 
     # This method needs special handling as it has a default argument value
     def build(attrs={})

--- a/lib/jira/resource/agile.rb
+++ b/lib/jira/resource/agile.rb
@@ -20,9 +20,7 @@ module JIRA
       end
 
       def self.get_board_issues(client, board_id, options = {})
-        options[:maxResults] ||= 100
         response = client.get(path_base(client) + "/board/#{board_id}/issue?#{hash_to_query_string(options)}")
-        parse_json(response.body)
         json = parse_json(response.body)
         # To get Issue objects with the same structure as for Issue.all
         issue_ids = json['issues'].map { |issue|

--- a/lib/jira/resource/agile.rb
+++ b/lib/jira/resource/agile.rb
@@ -19,6 +19,18 @@ module JIRA
         parse_json(response.body)
       end
 
+      def self.get_board_issues(client, board_id, options = {})
+        options[:maxResults] ||= 100
+        response = client.get(path_base(client) + "/board/#{board_id}/issue?maxResults=#{options[:maxResults]}")
+        parse_json(response.body)
+        json = parse_json(response.body)
+        # To get Issue objects with the same structure as for Issue.all
+        issue_ids = json['issues'].map { |issue|
+          issue['id']
+        }
+        client.Issue.jql("id IN(#{issue_ids.join(', ')})")
+      end
+
       def self.get_sprints(client, board_id, options = {})
         options[:maxResults] ||= 100
         response = client.get(path_base(client) + "/board/#{board_id}/sprint?#{hash_to_query_string(options)}")

--- a/lib/jira/resource/agile.rb
+++ b/lib/jira/resource/agile.rb
@@ -21,7 +21,7 @@ module JIRA
 
       def self.get_board_issues(client, board_id, options = {})
         options[:maxResults] ||= 100
-        response = client.get(path_base(client) + "/board/#{board_id}/issue?maxResults=#{options[:maxResults]}")
+        response = client.get(path_base(client) + "/board/#{board_id}/issue?#{hash_to_query_string(options)}")
         parse_json(response.body)
         json = parse_json(response.body)
         # To get Issue objects with the same structure as for Issue.all

--- a/spec/jira/resource/agile_spec.rb
+++ b/spec/jira/resource/agile_spec.rb
@@ -22,6 +22,26 @@ describe JIRA::Resource::Agile do
     end
   end
 
+  describe '#get_board_issues' do
+    it 'should query correct url without parameters' do
+      expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?maxResults=100').and_return(response)
+      expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
+
+      issues = JIRA::Resource::Agile.get_board_issues(client, 1)
+      expect(issues).to be_an(Array)
+      expect(issues.size).to eql(1)
+      expected_issue = client.Issue.build(JSON.parse(jql_issue.to_json))
+      expect(issues.first.attrs).to eql(expected_issue.attrs)
+    end
+
+    it 'should query correct url with parameters' do
+      expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?startAt=50&maxResults=100').and_return(response)
+      expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
+
+      JIRA::Resource::Agile.get_board_issues(client, 1, startAt: 50)
+    end
+  end
+
   describe '#get_sprints' do
     it 'should query correct url without parameters' do
       expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/sprint?maxResults=100').and_return(response)

--- a/spec/jira/resource/agile_spec.rb
+++ b/spec/jira/resource/agile_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 describe JIRA::Resource::Agile do
-  let(:client) { double(options: {rest_base_path: '/jira/rest/api/2', context_path: '/jira'}) }
+  let(:client) do
+    client = double(options: {rest_base_path: '/jira/rest/api/2', context_path: '/jira'})
+    allow(client).to receive(:Issue).and_return(JIRA::Resource::IssueFactory.new(client))
+    client
+  end
   let(:response) { double }
 
   describe '#all' do
@@ -25,20 +29,38 @@ describe JIRA::Resource::Agile do
   describe '#get_board_issues' do
     it 'should query correct url without parameters' do
       expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?maxResults=100').and_return(response)
+      expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json')).twice
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/search?jql=id+IN%2810546%2C+10547%2C+10556%2C+10557%2C+10558%2C+10559%2C+10600%2C+10601%2C+10604%29').and_return(response)
       expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
 
       issues = JIRA::Resource::Agile.get_board_issues(client, 1)
       expect(issues).to be_an(Array)
-      expect(issues.size).to eql(1)
-      expected_issue = client.Issue.build(JSON.parse(jql_issue.to_json))
-      expect(issues.first.attrs).to eql(expected_issue.attrs)
+      expect(issues.size).to eql(9)
+
+      issues.each do |issue|
+        expect(issue.class).to eq(JIRA::Resource::Issue)
+        expect(issue.expanded?).to be_falsey
+      end
+
     end
 
     it 'should query correct url with parameters' do
       expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?startAt=50&maxResults=100').and_return(response)
+      expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json')).twice
+
+      expect(client).to receive(:get).with('/jira/rest/api/2/search?jql=id+IN%2810546%2C+10547%2C+10556%2C+10557%2C+10558%2C+10559%2C+10600%2C+10601%2C+10604%29').and_return(response)
       expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
 
-      JIRA::Resource::Agile.get_board_issues(client, 1, startAt: 50)
+      issues = JIRA::Resource::Agile.get_board_issues(client, 1, startAt: 50)
+      expect(issues).to be_an(Array)
+      expect(issues.size).to eql(9)
+
+      issues.each do |issue|
+        expect(issue.class).to eq(JIRA::Resource::Issue)
+        expect(issue.expanded?).to be_falsey
+      end
+
     end
   end
 

--- a/spec/jira/resource/agile_spec.rb
+++ b/spec/jira/resource/agile_spec.rb
@@ -28,8 +28,8 @@ describe JIRA::Resource::Agile do
 
   describe '#get_board_issues' do
     it 'should query correct url without parameters' do
-      expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?maxResults=100').and_return(response)
-      expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json')).twice
+      expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?').and_return(response)
+      expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
 
       expect(client).to receive(:get).with('/jira/rest/api/2/search?jql=id+IN%2810546%2C+10547%2C+10556%2C+10557%2C+10558%2C+10559%2C+10600%2C+10601%2C+10604%29').and_return(response)
       expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
@@ -46,8 +46,8 @@ describe JIRA::Resource::Agile do
     end
 
     it 'should query correct url with parameters' do
-      expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?startAt=50&maxResults=100').and_return(response)
-      expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json')).twice
+      expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?startAt=50').and_return(response)
+      expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
 
       expect(client).to receive(:get).with('/jira/rest/api/2/search?jql=id+IN%2810546%2C+10547%2C+10556%2C+10557%2C+10558%2C+10559%2C+10600%2C+10601%2C+10604%29').and_return(response)
       expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))

--- a/spec/mock_responses/board/1_issues.json
+++ b/spec/mock_responses/board/1_issues.json
@@ -1,0 +1,62 @@
+{
+  "expand": "schema,names",
+  "startAt": 0,
+  "maxResults": 1000,
+  "total": 9,
+  "issues": [
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10546",
+      "self": "https://jira.example.com/rest/agile/1.0/issue/10546",
+      "key": "SBT-1"
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10547",
+      "self": "https://jira.example.com/rest/agile/1.0/issue/10547",
+      "key": "SBT-2"
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10556",
+      "self": "https://jira.example.com/rest/agile/1.0/issue/10556",
+      "key": "SBT-11"
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10557",
+      "self": "https://jira.example.com/rest/agile/1.0/issue/10557",
+      "key": "SBT-12"
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10558",
+      "self": "https://jira.example.com/rest/agile/1.0/issue/10558",
+      "key": "SBT-13"
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10559",
+      "self": "https://jira.example.com/rest/agile/1.0/issue/10559",
+      "key": "SBT-14"
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10600",
+      "self": "https://jira.example.com/rest/agile/1.0/issue/10600",
+      "key": "SBT-16"
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10601",
+      "self": "https://jira.example.com/rest/agile/1.0/issue/10601",
+      "key": "SBT-17"
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "10604",
+      "self": "https://jira.example.com/rest/agile/1.0/issue/10604",
+      "key": "SBT-19"
+    }
+  ]
+}


### PR DESCRIPTION
You can not receive all issues on a Kanban board with the rapidview REST API call. 
This only works for sprint boards. If you try to access a Kanban board through rapid view API you get an error which says that rapid board requires a project with a backlog.

To get all issues on a Kanban board the board API from agile module could be used. The /issue endpoint returns all known issues. I get all issues with a second call, equal to the implementation in rapidview.rb:+28.

This is my first pull request to a ruby project and my first project with rspec ever. I hope the stuff makes sense. Would be great to have a working gem soon :) 