### PR TITLE
Add source_code_uri to gemspec

### DIFF
--- a/jira-ruby.gemspec
+++ b/jira-ruby.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Ruby Gem for use with the Atlassian JIRA REST API}
   s.description = %q{API for JIRA}
   s.licenses    = ['MIT']
+  s.metadata    = { 'source_code_uri' => 'https://github.com/sumoheavy/jira-ruby' }
 
   s.required_ruby_version = '>= 1.9.3'
 


### PR DESCRIPTION
Makes it easy to programatically find the source code and changelog for `jira-ruby`, using the rubygems API. More details on the direction of travel for gemspecs is [here](https://github.com/rubygems/rubygems.org/issues/1127) and [here](https://github.com/rubygems/rubygems.org/pull/1234), and the current state is [here](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb).

(My interest in this is so that [Dependabot](https://dependabot.com) can find a link to the `jira-ruby` source code when it creates PRs. Without that link, we generate PRs like [this one](https://github.com/greysteil/shipment_tracker/pull/36), rather than PRs like [this one](https://github.com/greysteil/shipment_tracker/pull/34).)