### PR TITLE
Make all requests through HttpClient work with proxies

### DIFF
--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -138,6 +138,19 @@ describe JIRA::HttpClient do
     basic_client.make_request(:get, '/foo', body, headers)
   end
 
+  it "performs a basic http client request with a full domain" do
+    body = nil
+    headers = double()
+    basic_auth_http_conn = double()
+    http_request = double()
+    expect(Net::HTTP::Get).to receive(:new).with('/foo', headers).and_return(http_request)
+
+    expect(basic_auth_http_conn).to receive(:request).with(http_request).and_return(response)
+    expect(http_request).to receive(:basic_auth).with(basic_client.options[:username], basic_client.options[:password]).and_return(http_request)
+    allow(basic_client).to receive(:basic_auth_http_conn).and_return(basic_auth_http_conn)
+    basic_client.make_request(:get, 'http://mydomain.com/foo', body, headers)
+  end
+
   it "returns a URI" do
     uri = URI.parse(basic_client.options[:site])
     expect(basic_client.uri).to eq(uri)


### PR DESCRIPTION
Certain requests, such as those for an issue's `RemoteLink`, would fail because `Net::HTTP` would append the hostname to the full URL path if a proxy were in use. This PR changes this behavior to pass in the request path, since the hostname is already set in the `Net::HTTP.new` call.

Closes #250 