### PR TITLE
Removing leading slash from fully qualified URLs

### DIFF
--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -447,7 +447,7 @@ module JIRA
     # [07/Jun/2015:15:17:18 +0400] "PUT /jira/rest/api/2/issue/10111 HTTP/1.1" 204 -
     def patched_url
       result = url
-      return result if result.start_with?('/')
+      return result if result.start_with?('/', 'http')
       "/#{result}"
     end
 


### PR DESCRIPTION
I'm using this gem on a project that's configured to hit a JIRA service that's running on a different machine. The gem works fine to do all read operations—even creating a bug works OK. But for some reason, when calling `save!` or `save`, a leading `/` is added to my URLs. As a result, these requests come back `JIRA::HTTPError: Forbidden`.