### PR TITLE
Add new type of auth in options to support oauth 2legged for server version of JIRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ key.
 > After you have entered all the information click OK and ensure OAuth authentication is
 > enabled.
 
+For 2 legged oauth in server mode only, not in cloud based JIRA, make sure to `Allow 2-Legged OAuth`
+
 ## Configuring JIRA to use HTTP Basic Auth
 
 Follow the same steps described above to set up a new Application Link in JIRA,
@@ -387,5 +389,35 @@ class App < Sinatra::Base
     session.delete(:jira_auth)
     redirect "/"
   end
+end
+```
+
+## Using the API Gem in a 2 legged context
+
+Here's an example on how to use 2 legged OAuth:
+```ruby
+require 'rubygems'
+require 'pp'
+require 'jira-ruby'
+
+options = {
+            :site               => 'http://localhost:2990',
+            :context_path       => '/jira',
+            :signature_method   => 'RSA-SHA1',
+            :private_key_file   => "rsakey.pem",
+            :rest_base_path     => "/rest/api/2",
+            :auth_type => :oauth_2legged,
+            :consumer_key       => "jira-ruby-example"
+          }
+
+client = JIRA::Client.new(options)
+
+client.set_access_token("","")
+
+# Show all projects
+projects = client.Project.all
+
+projects.each do |project|
+  puts "Project -> key: #{project.key}, name: #{project.name}"
 end
 ```

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -62,7 +62,7 @@ module JIRA
       @options[:rest_base_path] = @options[:context_path] + @options[:rest_base_path]
 
       case options[:auth_type]
-      when :oauth
+      when :oauth, :oauth_2legged
         @request_client = OauthClient.new(@options)
         @consumer = @request_client.consumer
       when :basic
@@ -75,7 +75,7 @@ module JIRA
         @options.delete(:username)
         @options.delete(:password)
       else
-        raise ArgumentError, 'Options: ":auth_type" must be ":oauth", ":cookie" or ":basic"'
+        raise ArgumentError, 'Options: ":auth_type" must be ":oauth",":oauth_2legged", ":cookie" or ":basic"'
       end
 
       @http_debug = @options[:http_debug]

--- a/lib/jira/oauth_client.rb
+++ b/lib/jira/oauth_client.rb
@@ -74,6 +74,18 @@ module JIRA
     end
 
     def make_request(http_method, path, body='', headers={})
+      # When using oauth_2legged we need to add an empty oauth_token parameter to every request.
+      if @options[:auth_type] == :oauth_2legged
+        oauth_params_str = "oauth_token="
+        uri = URI.parse(path)
+        if uri.query.to_s == ""
+          uri.query = oauth_params_str
+        else
+          uri.query = uri.query + "&" + oauth_params_str
+        end
+        path = uri.to_s
+      end
+
       case http_method
       when :delete, :get, :head
         response = access_token.send http_method, path, headers

--- a/spec/jira/oauth_client_spec.rb
+++ b/spec/jira/oauth_client_spec.rb
@@ -107,5 +107,41 @@ describe JIRA::OauthClient do
         oauth_client.request(:get, '/foo', body, headers)
       end
     end
+
+    describe "auth type is oauth_2legged" do
+      let(:oauth__2legged_client) do
+        options = { :consumer_key => 'foo', :consumer_secret => 'bar', :auth_type => :oauth_2legged }
+        options = JIRA::Client::DEFAULT_OPTIONS.merge(options)
+        JIRA::OauthClient.new(options)
+      end
+
+      it "responds to the http methods adding oauth_token parameter" do
+        headers = double()
+        mock_access_token = double()
+        allow(oauth__2legged_client).to receive(:access_token).and_return(mock_access_token)
+        [:delete, :get, :head].each do |method|
+          expect(mock_access_token).to receive(method).with('/path?oauth_token=', headers).and_return(response)
+          oauth__2legged_client.make_request(method, '/path', '', headers)
+        end
+        [:post, :put].each do |method|
+          expect(mock_access_token).to receive(method).with('/path?oauth_token=', '', headers).and_return(response)
+          oauth__2legged_client.make_request(method, '/path', '', headers)
+        end
+      end
+
+      it "responds to the http methods adding oauth_token parameter to any existing parameters" do
+        headers = double()
+        mock_access_token = double()
+        allow(oauth__2legged_client).to receive(:access_token).and_return(mock_access_token)
+        [:delete, :get, :head].each do |method|
+          expect(mock_access_token).to receive(method).with('/path?any_param=toto&oauth_token=', headers).and_return(response)
+          oauth__2legged_client.make_request(method, '/path?any_param=toto', '', headers)
+        end
+        [:post, :put].each do |method|
+          expect(mock_access_token).to receive(method).with('/path?any_param=toto&oauth_token=', '', headers).and_return(response)
+          oauth__2legged_client.make_request(method, '/path?any_param=toto', '', headers)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
To support 2 legged oauth for JIRA server only, this is not supported in JIRA cloud, we need to add an `oauth_token` parameter to every request made to the JIRA Rest API.  _See ref A_

I've also added a sample in the ReadMe.

*References*
- Ref a: https://community.atlassian.com/t5/Answers-Developer-Questions/Trying-to-use-Scribe-library-for-2-legged-Oauth-in-JIRA/qaq-p/493695#M31351