### PR TITLE
Fix issuea all

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -40,12 +40,21 @@ module JIRA
       has_many :remotelink, :class => JIRA::Resource::Remotelink
 
       def self.all(client)
-        url = client.options[:rest_base_path] + "/search?expand=transitions.fields"
-        response = client.get(url)
-        json = parse_json(response.body)
-        json['issues'].map do |issue|
-          client.Issue.build(issue)
+        start_at = 0
+        max_results = 1000
+        result = []
+        loop do
+          url = client.options[:rest_base_path] +
+                "/search?expand=transitions.fields&maxResults=#{max_results}&startAt=#{start_at}"
+          response = client.get(url)
+          json = parse_json(response.body)
+          json['issues'].map do |issue|
+            result.push(client.Issue.build(issue))
+          end
+          break if json['issues'].size == 0
+          start_at += json['issues'].size
         end
+        result
       end
 
       def self.jql(client, jql, options = {fields: nil, start_at: nil, max_results: nil, expand: nil})

--- a/spec/integration/issue_spec.rb
+++ b/spec/integration/issue_spec.rb
@@ -46,8 +46,11 @@ describe JIRA::Resource::Issue do
         }
       }
       before(:each) do
-        stub_request(:get, site_url + "/jira/rest/api/2/search?expand=transitions.fields").
+        stub_request(:get, site_url + "/jira/rest/api/2/search?expand=transitions.fields&maxResults=1000&startAt=0").
                     to_return(:status => 200, :body => get_mock_response('issue.json'))
+
+        stub_request(:get, site_url + "/jira/rest/api/2/search?expand=transitions.fields&maxResults=1000&startAt=11").
+                    to_return(:status => 200, :body => get_mock_response('empty_issues.json'))
       end
       it_should_behave_like "a resource with a collection GET endpoint"
     end

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -37,11 +37,16 @@ describe JIRA::Resource::Issue do
 
   it "should find all issues" do
     response = double()
+    empty_response = double()
     issue = double()
 
     allow(response).to receive(:body).and_return('{"issues":[{"id":"1","summary":"Bugs Everywhere"}]}')
-    expect(client).to receive(:get).with('/jira/rest/api/2/search?expand=transitions.fields').
+    expect(client).to receive(:get).with('/jira/rest/api/2/search?expand=transitions.fields&maxResults=1000&startAt=0').
       and_return(response)
+    allow(empty_response).to receive(:body).and_return('{"issues":[]}')
+    expect(client).to receive(:get).with('/jira/rest/api/2/search?expand=transitions.fields&maxResults=1000&startAt=1').
+      and_return(empty_response)
+      
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with({"id"=>"1","summary"=>"Bugs Everywhere"})
 

--- a/spec/mock_responses/empty_issues.json
+++ b/spec/mock_responses/empty_issues.json
@@ -1,0 +1,8 @@
+{
+  "expand": "schema,names",
+  "startAt": 11,
+  "maxResults": 1000,
+  "total": 0,
+  "issues": [
+  ]
+}

--- a/spec/mock_responses/issue.json
+++ b/spec/mock_responses/issue.json
@@ -1,7 +1,7 @@
 {
   "expand": "schema,names",
   "startAt": 0,
-  "maxResults": 50,
+  "maxResults": 1000,
   "total": 11,
   "issues": [
     {


### PR DESCRIPTION
This should return ALL issues as it says it will.
Keeping count of the size of the result I currently have and then just appending to the array to return.
Setting a max result is optional but I did it anyway.
closes #143

ref: https://github.com/sumoheavy/jira-ruby/pull/174