### PR TITLE
Update the SDK installer URL to reflect current location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ rake jira:generate_public_cert
 
 On Mac OS,
 
-* Follow the instructions under "Mac OSX Installer" here: https://developer.atlassian.com/display/DOCS/Install+the+Atlassian+SDK+on+a+Linux+or+Mac+System
+* Follow the instructions under "Mac OSX Installer" here: https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-linux-or-mac-system
 * From within the archive directory, run:
 
 ```shell


### PR DESCRIPTION
Hi - Slight doc update for you. The older URL redirects me to a generic Atlassian page, but I think this one is what developers will ultimately want. 

Thought I'd submit a fix; open to feedback.