### PR TITLE
Find user by username/email/name.

### DIFF
--- a/lib/jira/resource/user.rb
+++ b/lib/jira/resource/user.rb
@@ -8,11 +8,28 @@ module JIRA
         instance.set_attrs_from_response(response)
         instance
       end
+
+      delegate_to_target_class :search, :search_path
     end
 
     class User < JIRA::Base
       def self.singular_path(client, key, prefix = '/')
         collection_path(client, prefix) + '?username=' + key
+      end
+
+      def self.search_path(client, search, prefix='/')
+        collection_path(client, prefix) + '/search?username=' + search
+      end
+
+      def self.search(client, search, options = {})
+        response = client.get(search_path(client, search))
+        json = parse_json(response.body)
+        if collection_attributes_are_nested
+          json = json[endpoint_name.pluralize]
+        end
+        json.map do |attrs|
+          self.new(client, { attrs: attrs }.merge(options))
+        end
       end
     end
 

--- a/spec/jira/resource/user_factory_spec.rb
+++ b/spec/jira/resource/user_factory_spec.rb
@@ -30,4 +30,16 @@ describe JIRA::Resource::UserFactory do
     end
   end
 
+  describe 'proxy' do
+    it "proxies search path to the target class" do
+      expect(JIRA::Resource::User).to receive(:search_path).with(client, 'FOO')
+      subject.search_path('FOO')
+    end
+
+    it "proxies search to the target class" do
+      expect(JIRA::Resource::User).to receive(:search).with(client, 'FOO')
+      subject.search('FOO')
+    end
+  end
+
 end

--- a/spec/jira/resource/user_spec.rb
+++ b/spec/jira/resource/user_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe JIRA::Resource::User do
+
+  let(:client) {
+    instance_double('Client', options: { rest_base_path: '/jira/rest/api/2' })
+  }
+
+  describe '#search' do
+    let(:response) {
+      instance_double('Response', body: '[' + get_mock_response('user_username=admin.json') + ']')
+    }
+
+    let(:users) { JIRA::Resource::User.search(client, 'admin@example.com') }
+    let(:user) { users.first }
+
+    before(:each) do
+      allow(client).to receive(:get).with(
+        '/jira/rest/api/2/user/search?username=admin@example.com'
+      ).and_return(response)
+    end
+
+    it 'returns a list with a user to search for' do
+      expect(client).to receive(:get).with('/jira/rest/api/2/user/search?username=admin@example.com').and_return(response)
+      expect(JIRA::Resource::User).to receive(:search_path).and_return('/jira/rest/api/2/user/search?username=admin@example.com')
+      expect(users.length).to eq 1
+      expect(user).to be_a(JIRA::Resource::User)
+      expect(user.name).to eq('admin')
+      expect(user.emailAddress).to eq('admin@example.com')
+      expect(user.expanded?).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Addresses https://github.com/sumoheavy/jira-ruby/issues/179

It can search for a user by email address (or name).
https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-user-search-get

Existing `User.find` seems to have a policy to receive only ID, so I believe it should give another name to this user search feature.

In my environment, the following works
```ruby
search = 'foo@example.com'
results = client.User.search(search)
user = results.first
```