### PR TITLE
message to return response body

### DIFF
--- a/lib/jira/http_error.rb
+++ b/lib/jira/http_error.rb
@@ -4,11 +4,12 @@ module JIRA
   class HTTPError < StandardError
     extend Forwardable
 
-    def_instance_delegators :@response, :message, :code
-    attr_reader :response
+    def_instance_delegators :@response, :code
+    attr_reader :response, :message
 
     def initialize(response)
       @response = response
+      @message = response.try(:message) || response.try(:body)
     end
 
   end


### PR DESCRIPTION
the message returns nil from jira on HTTPError which in an error response is sort of confusing. I had to go through the source code to find out how response was being stored. This PR stores the body in message so error.message will return the actual message from the server.