### PR TITLE
Remove superfluous question mark.

### DIFF
--- a/lib/jira/resource/board.rb
+++ b/lib/jira/resource/board.rb
@@ -31,7 +31,7 @@ module JIRA
       end
 
       def issues(params = {})
-        path = path_base(client) + "/board/#{id}/issue?"
+        path = path_base(client) + "/board/#{id}/issue"
         response = client.get(url_with_query_params(path, params))
         json = self.class.parse_json(response.body)
         results = json['issues']

--- a/spec/jira/resource/board_spec.rb
+++ b/spec/jira/resource/board_spec.rb
@@ -89,7 +89,7 @@ eos
 
       allow(issues_response).to receive(:body).and_return(api_json_issues)
       allow(board).to receive(:id).and_return(84)
-      expect(client).to receive(:get).with('/rest/agile/1.0/board/84/issue?')
+      expect(client).to receive(:get).with('/rest/agile/1.0/board/84/issue')
                                      .and_return(issues_response)
       expect(client).to receive(:Issue).and_return(JIRA::Resource::IssueFactory.new(client))
 


### PR DESCRIPTION
When getting the issues from a board, remove the superfluous question mark from the query string.

See #304