### PR TITLE
Add default headers

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -25,7 +25,8 @@ module JIRA
   #   :auth_type          => :oauth,
   #   :proxy_address      => nil,
   #   :proxy_port         => nil,
-  #   :additional_cookies => nil
+  #   :additional_cookies => nil,
+  #   :default_headers    => {}
   #
   # See the JIRA::Base class methods for all of the available methods on these accessor
   # objects.
@@ -52,7 +53,8 @@ module JIRA
       use_ssl: true,
       use_client_cert: false,
       auth_type: :oauth,
-      http_debug: false
+      http_debug: false,
+      default_headers: {}
     }.freeze
 
     def initialize(options = {})
@@ -241,7 +243,7 @@ module JIRA
     protected
 
     def merge_default_headers(headers)
-      { 'Accept' => 'application/json' }.merge(headers)
+      { 'Accept' => 'application/json' }.merge(headers).merge(@options[:default_headers])
     end
   end
 end

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -243,7 +243,7 @@ module JIRA
     protected
 
     def merge_default_headers(headers)
-      { 'Accept' => 'application/json' }.merge(headers).merge(@options[:default_headers])
+      { 'Accept' => 'application/json' }.merge(@options[:default_headers]).merge(headers)
     end
   end
 end


### PR DESCRIPTION
Add the option to send headers by default in each of the events.

In this way, it is possible to send extra headers to the JIRA server, for example, authentication codes or extra information of the authenticated user.

example:

> 

     options = {
                 : site => 'http://jiraexample.com',
                 : context_path => '/api/v1.2/jira',
                 : auth_type =>: cookie,
                 : use_cookies => true,
                 : http_debug => true,
                 : use_ssl => false,
                 : default_headers => {
                                    "API-KEY" => "HGDFSYE76G5D9",
                                    "CLIENT-EMAIL" => "luis.rangel@corp.com",
                                    "CLIENT-OFFICE => "Cloud devs"
                                                    }
     }
     client = JIRA :: Client.new (options)