### PR TITLE
Fetch all users correctly for on-prem customers

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -208,6 +208,10 @@ module JIRA
       @request_client.request(http_method, path, body, headers)
     end
 
+    def cloud_instance?
+      options[:site].include?("atlassian.net")
+    end
+
     protected
 
       def merge_default_headers(headers)

--- a/lib/jira/resource/user.rb
+++ b/lib/jira/resource/user.rb
@@ -13,7 +13,8 @@ module JIRA
 
       # Cannot retrieve more than 1,000 users through the api, please see: https://jira.atlassian.com/browse/JRASERVER-65089
       def self.all(client)
-        response  = client.get("/rest/api/2/user/search?username=_&maxResults=#{MAX_RESULTS}")
+        search_token = client.cloud_instance? ? "_" : "@"
+        response  = client.get("/rest/api/2/user/search?username=#{search_token}&maxResults=#{MAX_RESULTS}")
         all_users = JSON.parse(response.body)
 
         all_users.flatten.uniq.map do |user|

--- a/spec/jira/client_spec.rb
+++ b/spec/jira/client_spec.rb
@@ -185,4 +185,32 @@ describe JIRA::Client do
       expect(basic_client.Project.find('123')).to eq(find_result)
     end
   end
+
+  describe "#cloud_instance?" do
+    let(:client) { JIRA::Client.new({ :username => 'foo', :password => 'bar', :auth_type => :basic, site: site }) }
+
+    context "when site is not present in options" do
+      let(:site) { "" }
+
+      it "returns false" do
+        expect(client).to_not be_cloud_instance
+      end
+    end
+
+    context "when the site has a cloud url" do
+      let(:site) { "https://foo.atlassian.net" }
+
+      it "returns true" do
+        expect(client).to be_cloud_instance
+      end
+    end
+
+    context "when the site does not have a cloud url (does not reference atlassian)" do
+      let(:site) { "https://foo.onprem.com" }
+
+      it "returns false" do
+        expect(client).to_not be_cloud_instance
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [ ] [User Mappings page does not populate the list of JIRA users](https://www.pivotaltracker.com/story/show/160211730)

#### Technical Changes
On-prem Jira uses '@' for a wildcard when searching, whereas cloud-based uses '_' for wildcard searching, so we added in some logic for determining if the user has a cloud-based Jira instance and then using that check to determine which wildcard symbol we should use when fetching all users.