### PR TITLE
Add functionality to use JWT authorisation in JiraCloud

### DIFF
--- a/jira-ruby.gemspec
+++ b/jira-ruby.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   # Runtime Dependencies
   s.add_runtime_dependency 'activesupport'
+  s.add_runtime_dependency 'atlassian-jwt'
   s.add_runtime_dependency 'multipart-post'
   s.add_runtime_dependency 'oauth', '~> 0.5', '>= 0.5.0'
 

--- a/lib/jira-ruby.rb
+++ b/lib/jira-ruby.rb
@@ -42,6 +42,7 @@ require 'jira/resource/board'
 require 'jira/request_client'
 require 'jira/oauth_client'
 require 'jira/http_client'
+require 'jira/jwt_client'
 require 'jira/client'
 
 require 'jira/railtie' if defined?(Rails)

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -71,6 +71,8 @@ module JIRA
       when :oauth, :oauth_2legged
         @request_client = OauthClient.new(@options)
         @consumer = @request_client.consumer
+      when :jwt
+        @request_client = JwtClient.new(@options)
       when :basic
         @request_client = HttpClient.new(@options)
       when :cookie

--- a/lib/jira/jwt_client.rb
+++ b/lib/jira/jwt_client.rb
@@ -1,0 +1,32 @@
+require 'atlassian/jwt'
+
+module JIRA
+  class JwtClient < HttpClient
+    def make_request(http_method, url, body = '', headers = {})
+      # When a proxy is enabled, Net::HTTP expects that the request path omits the domain name
+      path = request_path(url) + "?jwt=#{jwt_header(http_method, url)}"
+
+      request = Net::HTTP.const_get(http_method.to_s.capitalize).new(path, headers)
+      request.body = body unless body.nil?
+
+      response = basic_auth_http_conn.request(request)
+      @authenticated = response.is_a? Net::HTTPOK
+      store_cookies(response) if options[:use_cookies]
+      response
+    end
+
+    private
+
+    def jwt_header(http_method, url)
+      claim = Atlassian::Jwt.build_claims \
+        @options[:issuer],
+        url,
+        http_method.to_s,
+        @options[:site],
+        (Time.now - 60).to_i,
+        (Time.now + (86400)).to_i
+
+      JWT.encode claim, @options[:shared_secret]
+    end
+  end
+end


### PR DESCRIPTION
This will add functionality to this gem to make use of JWT authorisation, mainly needed for use with JiraCloud. Example usage:

```
 options = {
   site: 'http://jiraexample.com',
   context_path => '/api/v1.2/jira',
   auth_type: : jwt,

   : http_debug => true,
   : use_ssl => false,
 }
 client = JIRA :: Client.new (options)
```