### PR TITLE
Add multipart attachments for all client types

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -227,6 +227,11 @@ module JIRA
       request(:post, path, body, merge_default_headers(headers))
     end
 
+    def post_multipart(path, file, headers = {})
+      puts "post multipart: #{path} - [#{file}]" if @http_debug
+      @request_client.request_multipart(path, file, headers)
+    end
+
     def put(path, body = '', headers = {})
       headers = { 'Content-Type' => 'application/json' }.merge(headers)
       request(:put, path, body, merge_default_headers(headers))

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -33,9 +33,9 @@ module JIRA
       execute_request(request)
     end
 
-    def make_multipart_request(url, data, headers = {})
+    def make_multipart_request(url, body, headers = {})
       path = request_path(url)
-      request = Net::HTTP::Post::Multipart.new path, data, headers
+      request = Net::HTTP::Post::Multipart.new(path, body, headers)
 
       execute_request(request)
     end

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -29,12 +29,15 @@ module JIRA
       path = request_path(url)
       request = Net::HTTP.const_get(http_method.to_s.capitalize).new(path, headers)
       request.body = body unless body.nil?
-      add_cookies(request) if options[:use_cookies]
-      request.basic_auth(@options[:username], @options[:password]) if @options[:username] && @options[:password]
-      response = basic_auth_http_conn.request(request)
-      @authenticated = response.is_a? Net::HTTPOK
-      store_cookies(response) if options[:use_cookies]
-      response
+
+      execute_request(request)
+    end
+
+    def make_multipart_request(url, data, headers = {})
+      path = request_path(url)
+      request = Net::HTTP::Post::Multipart.new path, data, headers
+
+      execute_request(request)
     end
 
     def basic_auth_http_conn
@@ -60,7 +63,7 @@ module JIRA
     end
 
     def uri
-      uri = URI.parse(@options[:site])
+      URI.parse(@options[:site])
     end
 
     def authenticated?
@@ -68,6 +71,17 @@ module JIRA
     end
 
     private
+
+    def execute_request(request)
+      add_cookies(request) if options[:use_cookies]
+      request.basic_auth(@options[:username], @options[:password]) if @options[:username] && @options[:password]
+
+      response = basic_auth_http_conn.request(request)
+      @authenticated = response.is_a? Net::HTTPOK
+      store_cookies(response) if options[:use_cookies]
+
+      response
+    end
 
     def request_path(url)
       parsed_uri = URI(url)

--- a/lib/jira/http_error.rb
+++ b/lib/jira/http_error.rb
@@ -8,7 +8,7 @@ module JIRA
 
     def initialize(response)
       @response = response
-      @message = response.try(:message) || response.try(:body)
+      @message = response.try(:message).presence || response.try(:body)
     end
   end
 end

--- a/lib/jira/jwt_client.rb
+++ b/lib/jira/jwt_client.rb
@@ -52,7 +52,9 @@ module JIRA
 
     private
 
-    def request_path(http_method, url)
+    attr_reader :http_method
+
+    def request_path(url)
       JwtUriBuilder.new(
         url,
         http_method.to_s,

--- a/lib/jira/jwt_client.rb
+++ b/lib/jira/jwt_client.rb
@@ -3,16 +3,15 @@ require 'atlassian/jwt'
 module JIRA
   class JwtClient < HttpClient
     def make_request(http_method, url, body = '', headers = {})
-      # When a proxy is enabled, Net::HTTP expects that the request path omits the domain name
-      path = request_path(http_method, url)
+      @http_method = http_method
 
-      request = Net::HTTP.const_get(http_method.to_s.capitalize).new(path, headers)
-      request.body = body unless body.nil?
+      super(http_method, url, body, headers)
+    end
 
-      response = basic_auth_http_conn.request(request)
-      @authenticated = response.is_a? Net::HTTPOK
-      store_cookies(response) if options[:use_cookies]
-      response
+    def make_multipart_request(url, data, headers = {})
+      @http_method = :post
+
+      super(url, data, headers)
     end
 
     class JwtUriBuilder

--- a/lib/jira/oauth_client.rb
+++ b/lib/jira/oauth_client.rb
@@ -72,25 +72,35 @@ module JIRA
       @access_token
     end
 
-    def make_request(http_method, path, body = '', headers = {})
+    def make_request(http_method, url, body = '', headers = {})
       # When using oauth_2legged we need to add an empty oauth_token parameter to every request.
       if @options[:auth_type] == :oauth_2legged
         oauth_params_str = 'oauth_token='
-        uri = URI.parse(path)
+        uri = URI.parse(url)
         uri.query = if uri.query.to_s == ''
                       oauth_params_str
                     else
                       uri.query + '&' + oauth_params_str
                     end
-        path = uri.to_s
+        url = uri.to_s
       end
 
       case http_method
       when :delete, :get, :head
-        response = access_token.send http_method, path, headers
+        response = access_token.send http_method, url, headers
       when :post, :put
-        response = access_token.send http_method, path, body, headers
+        response = access_token.send http_method, url, body, headers
       end
+      @authenticated = true
+      response
+    end
+
+    def make_multipart_request(url, data, headers = {})
+      request = Net::HTTP::Post::Multipart.new url, data, headers
+
+      access_token.sign! request
+
+      response = consumer.http.request(request)
       @authenticated = true
       response
     end

--- a/lib/jira/request_client.rb
+++ b/lib/jira/request_client.rb
@@ -1,7 +1,6 @@
 require 'oauth'
 require 'json'
 require 'net/https'
-# require 'pry'
 
 module JIRA
   class RequestClient
@@ -11,9 +10,22 @@ module JIRA
 
     def request(*args)
       response = make_request(*args)
-      # binding.pry unless response.kind_of?(Net::HTTPSuccess)
       raise HTTPError, response unless response.is_a?(Net::HTTPSuccess)
       response
+    end
+
+    def request_multipart(*args)
+      response = make_multipart_request(*args)
+      raise HTTPError, response unless response.is_a?(Net::HTTPSuccess)
+      response
+    end
+
+    def make_request(*args)
+      raise NotImplementedError
+    end
+
+    def make_multipart_request(*args)
+      raise NotImplementedError
     end
   end
 end

--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -21,7 +21,8 @@ module JIRA
 
       def save!(attrs)
         headers = { 'X-Atlassian-Token' => 'no-check' }
-        data = { 'file' => UploadIO.new(attrs[:file], 'application/binary', attrs[:file]) }
+        file = attrs['file'] || attrs[:file]
+        data = { 'file' => UploadIO.new(file, 'application/binary', file) }
 
         # Execute the multipart post here
         response = client.post_multipart(url, data , headers)

--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -20,25 +20,28 @@ module JIRA
       end
 
       def save!(attrs)
-        headers = { 'X-Atlassian-Token' => 'nocheck' }
-        data = { 'file' => UploadIO.new(attrs['file'], 'application/binary', attrs['file']) }
+        headers = { 'X-Atlassian-Token' => 'no-check' }
+        data = { 'file' => UploadIO.new(attrs[:file], 'application/binary', attrs[:file]) }
 
-        request = Net::HTTP::Post::Multipart.new url, data, headers
-        request.basic_auth(client.request_client.options[:username],
-                           client.request_client.options[:password])
+        # Execute the multipart post here
+        response = client.post_multipart(url, data , headers)
 
-        response = client.request_client.basic_auth_http_conn.request(request)
-
-        set_attrs(attrs, false)
-        unless response.body.nil? || response.body.length < 2
-          json = self.class.parse_json(response.body)
-          attachment = json[0]
-
-          set_attrs(attachment)
-        end
+        set_attributes(attrs, response)
 
         @expanded = false
         true
+      end
+
+      private
+
+      def set_attributes(attributes, response)
+        set_attrs(attributes, false)
+        return if response.body.nil? || response.body.length < 2
+
+        json = self.class.parse_json(response.body)
+        attachment = json[0]
+
+        set_attrs(attachment)
       end
     end
   end

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -254,24 +254,26 @@ describe JIRA::HttpClient do
   end
 
   describe '#make_multipart_request' do
-    subject { JIRA::HttpClient.new(client_options).make_multipart_request(path, data, headers) }
+    subject do
+      basic_client.make_multipart_request(path, data, headers)
+    end
 
-    let(:client_options) { JIRA::Client::DEFAULT_OPTIONS.merge(JIRA::HttpClient::DEFAULT_OPTIONS) }
-    let(:headers) { { 'X-Atlassian-Token' => 'no-check' } }
-    let(:data) { {} }
     let(:path) { '/foo' }
+    let(:data) { {} }
+    let(:headers) { { 'X-Atlassian-Token' => 'no-check' } }
     let(:basic_auth_http_conn) { double }
-    let(:request){  double }
+    let(:request) { double('Http Request', path: path) }
     let(:response) { double('response') }
 
     before do
       allow(request).to receive(:basic_auth)
-      allow(response).to receive(:get_fields).with('set-cookie')
       allow(Net::HTTP::Post::Multipart).to receive(:new).with(path, data, headers).and_return(request)
+      allow(basic_client).to receive(:basic_auth_http_conn).and_return(basic_auth_http_conn)
+      allow(basic_auth_http_conn).to receive(:request).with(request).and_return(response)
     end
 
     it 'performs a basic http client request' do
-      expect(request).to receive(:basic_auth).with(client.options[:username], client.options[:password]).and_return(request)
+      expect(request).to receive(:basic_auth).with(basic_client.options[:username], basic_client.options[:password]).and_return(request)
 
       subject
     end

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -252,4 +252,35 @@ describe JIRA::HttpClient do
     expect(basic_client).to receive(:http_conn).and_return(http_conn)
     expect(basic_client.basic_auth_http_conn).to eq(http_conn)
   end
+
+  describe '#make_multipart_request' do
+    subject { JIRA::HttpClient.new(client_options).make_multipart_request(path, data, headers) }
+
+    let(:client_options) { JIRA::Client::DEFAULT_OPTIONS.merge(JIRA::HttpClient::DEFAULT_OPTIONS) }
+    let(:headers) { { 'X-Atlassian-Token' => 'no-check' } }
+    let(:data) { {} }
+    let(:path) { '/foo' }
+    let(:basic_auth_http_conn) { double }
+    let(:request){  double }
+    let(:response) { double('response') }
+
+    before do
+      allow(request).to receive(:basic_auth)
+      allow(response).to receive(:get_fields).with('set-cookie')
+      allow(Net::HTTP::Post::Multipart).to receive(:new).with(path, data, headers).and_return(request)
+    end
+
+    it 'performs a basic http client request' do
+      expect(request).to receive(:basic_auth).with(client.options[:username], client.options[:password]).and_return(request)
+
+      subject
+    end
+
+    it 'makes a correct HTTP request' do
+      expect(basic_auth_http_conn).to receive(:request).with(request).and_return(response)
+      expect(response).to receive(:is_a?).with(Net::HTTPOK)
+
+      subject
+    end
+  end
 end

--- a/spec/jira/request_client_spec.rb
+++ b/spec/jira/request_client_spec.rb
@@ -1,14 +1,41 @@
 require 'spec_helper'
 
 describe JIRA::RequestClient do
-  it 'raises an exception for non success responses' do
-    response = double
-    allow(response).to receive(:kind_of?).with(Net::HTTPSuccess).and_return(false)
-    rc = JIRA::RequestClient.new
-    expect(rc).to receive(:make_request).with(:get, '/foo', '', {}).and_return(response)
+  let(:request_client) { JIRA::RequestClient.new }
 
-    expect do
-      rc.request(:get, '/foo', '', {})
-    end.to raise_exception(JIRA::HTTPError)
+  describe '#request' do
+    subject(:request) { request_client.request(:get, '/foo', '', {}) }
+
+    context 'when doing a request fails' do
+      let(:response) { double }
+
+      before do
+        allow(response).to receive(:kind_of?).with(Net::HTTPSuccess).and_return(false)
+        allow(request_client).to receive(:make_request).with(:get, '/foo', '', {}).and_return(response)
+      end
+
+      it 'raises an exception' do
+        expect{ subject }.to raise_exception(JIRA::HTTPError)
+      end
+    end
+  end
+
+  describe '#request_multipart' do
+    subject(:request) { request_client.request_multipart('/foo', data, {}) }
+
+    let(:data) { double }
+
+    context 'when doing a request fails' do
+      let(:response) { double }
+
+      before do
+        allow(response).to receive(:kind_of?).with(Net::HTTPSuccess).and_return(false)
+        allow(request_client).to receive(:make_multipart_request).with('/foo', data, {}).and_return(response)
+      end
+
+      it 'raises an exception' do
+        expect{ subject }.to raise_exception(JIRA::HTTPError)
+      end
+    end
   end
 end

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -60,9 +60,10 @@ describe JIRA::Resource::Attachment do
   end
 
   describe '#save' do
-    it 'successfully update the attachment' do
-      basic_auth_http_conn = double
-      response = double(
+    subject { attachment.save('file' => path_to_file) }
+    let(:path_to_file) { './spec/mock_responses/issue.json' }
+    let(:response) do
+      double(
         body: [
           {
             "id": 10_001,
@@ -74,14 +75,15 @@ describe JIRA::Resource::Attachment do
           }
         ].to_json
       )
+    end
+    let(:issue) { JIRA::Resource::Issue.new(client) }
 
-      allow(client.request_client).to receive(:basic_auth_http_conn).and_return(basic_auth_http_conn)
-      allow(basic_auth_http_conn).to receive(:request).and_return(response)
+    before do
+      allow(client).to receive(:post_multipart).and_return(response)
+    end
 
-      issue = JIRA::Resource::Issue.new(client)
-      path_to_file = './spec/mock_responses/issue.json'
-      attachment = JIRA::Resource::Attachment.new(client, issue: issue)
-      attachment.save('file' => path_to_file)
+    it 'successfully update the attachment' do
+      subject
 
       expect(attachment.filename).to eq 'picture.jpg'
       expect(attachment.mimeType).to eq 'image/jpeg'

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -60,7 +60,7 @@ describe JIRA::Resource::Attachment do
   end
 
   describe '#save!' do
-    subject { attachment.save!(:file => path_to_file) }
+    subject { attachment.save!('file' => path_to_file) }
 
     let(:path_to_file) { './spec/mock_responses/issue.json' }
     let(:response) do
@@ -89,6 +89,18 @@ describe JIRA::Resource::Attachment do
       expect(attachment.filename).to eq 'picture.jpg'
       expect(attachment.mimeType).to eq 'image/jpeg'
       expect(attachment.size).to eq 23_123
+    end
+
+    context 'when passing in a symbol as file key' do
+      subject { attachment.save!(file: path_to_file) }
+
+      it 'successfully update the attachment' do
+        subject
+
+        expect(attachment.filename).to eq 'picture.jpg'
+        expect(attachment.mimeType).to eq 'image/jpeg'
+        expect(attachment.size).to eq 23_123
+      end
     end
   end
 end


### PR DESCRIPTION
The current implementation of attachments only works when using the `basic_auth` client types.

This PR will add functionality so attachments can be used by all client types available.
Next to that some of the specs are refactored a bit.