### PR TITLE
Add BoardConfiguration API

### DIFF
--- a/lib/jira-ruby.rb
+++ b/lib/jira-ruby.rb
@@ -38,6 +38,7 @@ require 'jira/resource/createmeta'
 require 'jira/resource/webhook'
 require 'jira/resource/agile'
 require 'jira/resource/board'
+require 'jira/resource/board_configuration'
 
 require 'jira/request_client'
 require 'jira/oauth_client'

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -159,6 +159,10 @@ module JIRA
       JIRA::Resource::BoardFactory.new(self)
     end
 
+    def BoardConfiguration
+      JIRA::Resource::BoardConfigurationFactory.new(self)
+    end
+
     def RapidView
       JIRA::Resource::RapidViewFactory.new(self)
     end

--- a/lib/jira/resource/board.rb
+++ b/lib/jira/resource/board.rb
@@ -46,6 +46,13 @@ module JIRA
         results.map { |issue| client.Issue.build(issue) }
       end
 
+      def configuration(params = {})
+        path = path_base(client) + "/board/#{id}/configuration"
+        response = client.get(url_with_query_params(path, params))
+        json = self.class.parse_json(response.body)
+        client.BoardConfiguration.build(json)
+      end
+
       # options
       #   - state ~ future, active, closed, you can define multiple states separated by commas, e.g. state=active,closed
       #   - maxResults ~ default: 50 (JIRA API), 1000 (this library)

--- a/lib/jira/resource/board_configuration.rb
+++ b/lib/jira/resource/board_configuration.rb
@@ -1,0 +1,9 @@
+module JIRA
+  module Resource
+    class BoardConfigurationFactory < JIRA::BaseFactory # :nodoc:
+    end
+
+    class BoardConfiguration < JIRA::Base
+    end
+  end
+end

--- a/spec/jira/resource/board_spec.rb
+++ b/spec/jira/resource/board_spec.rb
@@ -172,4 +172,53 @@ eos
     expect(client).to receive(:Sprint).twice.and_return(JIRA::Resource::SprintFactory.new(client))
     expect(board.sprints.size).to be(2)
   end
+
+  it 'should get board configuration for a board' do
+    response = double
+
+    api_json = <<-eos
+      {
+        "id":1,
+        "name":"My Board",
+        "type":"kanban",
+        "self":"https://mycompany.atlassian.net/rest/agile/1.0/board/1/configuration",
+        "location":{
+          "type":"project",
+          "key":"MYPROJ",
+          "id":"10000",
+          "self":"https://mycompany.atlassian.net/rest/api/2/project/10000",
+          "name":"My Project"
+        },
+        "filter":{
+          "id":"10000",
+          "self":"https://mycompany.atlassian.net/rest/api/2/filter/10000"
+        },
+        "subQuery":{
+          "query":"resolution = EMPTY OR resolution != EMPTY AND resolutiondate >= -5d"
+        },
+        "columnConfig":{
+          "columns":[
+            {
+              "name":"Backlog",
+              "statuses":[
+                {
+                  "id":"10000",
+                  "self":"https://mycompany.atlassian.net/rest/api/2/status/10000"
+                }
+              ]
+            }
+          ],
+          "constraintType":"issueCount"
+        },
+        "ranking":{
+          "rankCustomFieldId":10011
+        }
+      }
+    eos
+    allow(response).to receive(:body).and_return(api_json)
+    allow(board).to receive(:id).and_return(84)
+    expect(client).to receive(:get).with('/rest/agile/1.0/board/84/configuration').and_return(response)
+    expect(client).to receive(:BoardConfiguration).and_return(JIRA::Resource::BoardConfigurationFactory.new(client))
+    expect(board.configuration).not_to be(nil)
+  end
 end


### PR DESCRIPTION
Why?
Allow for lookup of configuration information for a specific board.

See JIRA API documentation:
https://developer.atlassian.com/cloud/jira/software/rest/#api-rest-agile-1-0-board-boardId-configuration-get

Completes #316