### PR TITLE
Fix save method not working on attachments

### DIFF
--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -19,11 +19,11 @@ module JIRA
         parse_json(response.body)
       end
 
-      def save!(attrs)
+      def save!(attrs, path = url)
         headers = { 'X-Atlassian-Token' => 'nocheck' }
         data = { 'file' => UploadIO.new(attrs['file'], 'application/binary', attrs['file']) }
 
-        request = Net::HTTP::Post::Multipart.new url, data, headers
+        request = Net::HTTP::Post::Multipart.new path, data, headers
         request.basic_auth(client.request_client.options[:username],
                            client.request_client.options[:password])
 

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -49,6 +49,36 @@ describe JIRA::Resource::Attachment do
     end
   end
 
+  describe '#save' do
+    it 'successfully update the attachment' do
+      basic_auth_http_conn = double
+      response = double(
+        body: [
+          {
+            "id": 10_001,
+            "self": 'http://www.example.com/jira/rest/api/2.0/attachments/10000',
+            "filename": 'picture.jpg',
+            "created": '2017-07-19T12:23:06.572+0000',
+            "size": 23_123,
+            "mimeType": 'image/jpeg'
+          }
+        ].to_json
+      )
+
+      allow(client.request_client).to receive(:basic_auth_http_conn).and_return(basic_auth_http_conn)
+      allow(basic_auth_http_conn).to receive(:request).and_return(response)
+
+      issue = JIRA::Resource::Issue.new(client)
+      path_to_file = './spec/mock_responses/issue.json'
+      attachment = JIRA::Resource::Attachment.new(client, issue: issue)
+      attachment.save('file' => path_to_file)
+
+      expect(attachment.filename).to eq 'picture.jpg'
+      expect(attachment.mimeType).to eq 'image/jpeg'
+      expect(attachment.size).to eq 23_123
+    end
+  end
+
   describe '#save!' do
     it 'successfully update the attachment' do
       basic_auth_http_conn = double


### PR DESCRIPTION
When calling `save` on an attachment, the base class calls the `save!` method with two parameters (attrs, path), causing it to fail with `wrong number of arguments`.

This fixes #314.