### PR TITLE
Add mimeType parameter to make JIRA image preview work

### DIFF
--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -20,8 +20,10 @@ module JIRA
       end
 
       def save!(attrs)
+        file = attrs['file'] || attrs[:file] # Keep supporting 'file' parameter as a string for backward compatibility
+        mime_type = attrs[:mimeType] || 'application/binary'
         headers = { 'X-Atlassian-Token' => 'nocheck' }
-        data = { 'file' => UploadIO.new(attrs['file'], 'application/binary', attrs['file']) }
+        data = { 'file' => UploadIO.new(file, mime_type, file) }
 
         request = Net::HTTP::Post::Multipart.new url, data, headers
         request.basic_auth(client.request_client.options[:username],

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -71,7 +71,7 @@ describe JIRA::Resource::Attachment do
       issue = JIRA::Resource::Issue.new(client)
       path_to_file = './spec/mock_responses/issue.json'
       attachment = JIRA::Resource::Attachment.new(client, issue: issue)
-      attachment.save!('file' => path_to_file)
+      attachment.save!('file' => path_to_file, mimeType: 'image/jpeg')
 
       expect(attachment.filename).to eq 'picture.jpg'
       expect(attachment.mimeType).to eq 'image/jpeg'


### PR DESCRIPTION
When uploading image attachments to JIRA with the current `application/binary` forced mimeType, image previews does not work. The thumbnail is generated and shown properly, but clicking the file opens a dialog saying: "Ouch! We can't preview this file type."

Setting the correct mimeType for the image makes the preview dialog work.

I used symbols for hash keys instead of strings to standardize with the other examples. There's a check to make sure that the old `'file'` argument as string is still supported for backwards compatibility.