### PR TITLE
Fixed support for adding watchers to issues

### DIFF
--- a/lib/jira/resource/watcher.rb
+++ b/lib/jira/resource/watcher.rb
@@ -23,6 +23,13 @@ module JIRA
           issue.watchers.build(watcher)
         end
       end
+
+      def save!(user_id, path = nil)
+        path ||= new_record? ? url : patched_url
+        response = client.post(path, user_id.to_json)
+        true
+      end
+
     end
   end
 end

--- a/spec/integration/watcher_spec.rb
+++ b/spec/integration/watcher_spec.rb
@@ -33,21 +33,30 @@ describe JIRA::Resource::Watcher do
     end
 
     describe 'watchers' do
-      it 'should returns all the watchers' do
-        stub_request(:get,
-                     site_url + '/jira/rest/api/2/issue/10002')
+      before(:each) do
+        stub_request(:get, site_url + '/jira/rest/api/2/issue/10002')
           .to_return(status: 200, body: get_mock_response('issue/10002.json'))
 
-        stub_request(:get,
-                     site_url + '/jira/rest/api/2/issue/10002/watchers')
+        stub_request(:get, site_url + '/jira/rest/api/2/issue/10002/watchers')
           .to_return(status: 200, body: get_mock_response('issue/10002/watchers.json'))
 
+        stub_request(:post, site_url + '/jira/rest/api/2/issue/10002/watchers')
+          .to_return(status: 204, body: nil)
+      end
+
+      it 'should returns all the watchers' do
         issue = client.Issue.find('10002')
         watchers = client.Watcher.all(options = { issue: issue })
         expect(watchers.length).to eq(1)
       end
+
+      it 'should add a watcher' do
+        issue = client.Issue.find('10002')
+        watcher = JIRA::Resource::Watcher.new(client, issue: issue)
+        user_id = "tester"
+        watcher.save!(user_id)
+      end
     end
 
-    it_should_behave_like 'a resource'
   end
 end


### PR DESCRIPTION
When adding a watcher to a Jira issue, the API request succeeds but jira-ruby throws the following NoMethodError:
`undefined method 'each' for "kevin":String`
immediately afterwards when trying to parse and set attributes from the request body.

The reason for this bug is because the [Jira API endpoint for adding a watcher to an issue requires a regular string for the request body, rather than hash](https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-issue-issueIdOrKey-watchers-post) (with a string being a user id, like "kevin"), whereas most other endpoints require a hash. The default save! method in `base.rb` attempts to parse and set key-value attributes from the request body, but iteration (each) can't be done over a regular string like with a hash.

In this PR I override the save! method for watchers specifically, so it will not try to parse the body for attributes. I also wrote tests that mimic Jira's add watcher endpoint in which `base.rb`'s save! method throws the error

This PR also fixes support for adding watchers to issues, closing #118, which can be done like this:
```ruby
watcher = JIRA::Resource::Watcher.new(client, issue: issue)
watcher.save!(user_id)
```
