### PR TITLE
Fix a bug with multiple params for JTW clients

### DIFF
--- a/lib/jira/jwt_client.rb
+++ b/lib/jira/jwt_client.rb
@@ -4,7 +4,7 @@ module JIRA
   class JwtClient < HttpClient
     def make_request(http_method, url, body = '', headers = {})
       # When a proxy is enabled, Net::HTTP expects that the request path omits the domain name
-      path = request_path(url) + "?jwt=#{jwt_header(http_method, url)}"
+      path = request_path(http_method, url)
 
       request = Net::HTTP.const_get(http_method.to_s.capitalize).new(path, headers)
       request.body = body unless body.nil?
@@ -15,18 +15,52 @@ module JIRA
       response
     end
 
+    class JwtUriBuilder
+      attr_reader :request_url, :http_method, :shared_secret, :site, :issuer
+
+      def initialize(request_url, http_method, shared_secret, site, issuer)
+        @request_url = request_url
+        @http_method = http_method
+        @shared_secret = shared_secret
+        @site = site
+        @issuer = issuer
+      end
+
+      def build
+        uri = URI.parse(request_url)
+        new_query = URI.decode_www_form(String(uri.query)) << ['jwt', jwt_header]
+        uri.query = URI.encode_www_form(new_query)
+
+        return uri.to_s unless uri.is_a?(URI::HTTP)
+
+        uri.request_uri
+      end
+
+      private
+
+      def jwt_header
+        claim = Atlassian::Jwt.build_claims \
+          issuer,
+          request_url,
+          http_method.to_s,
+          site,
+          (Time.now - 60).to_i,
+          (Time.now + 86_400).to_i
+
+        JWT.encode claim, shared_secret
+      end
+    end
+
     private
 
-    def jwt_header(http_method, url)
-      claim = Atlassian::Jwt.build_claims \
-        @options[:issuer],
+    def request_path(http_method, url)
+      JwtUriBuilder.new(
         url,
         http_method.to_s,
+        @options[:shared_secret],
         @options[:site],
-        (Time.now - 60).to_i,
-        (Time.now + (86400)).to_i
-
-      JWT.encode claim, @options[:shared_secret]
+        @options[:issuer]
+      ).build
     end
   end
 end

--- a/spec/jira/jwt_uri_builder_spec.rb
+++ b/spec/jira/jwt_uri_builder_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe JIRA::JwtClient::JwtUriBuilder do
+  subject(:url_builder) do
+    JIRA::JwtClient::JwtUriBuilder.new(url, http_method, shared_secret, site, issuer)
+  end
+
+  let(:url) { '/foo' }
+  let(:http_method) { :get }
+  let(:shared_secret) { 'shared_secret' }
+  let(:site) { 'http://localhost:2990' }
+  let(:issuer) { nil }
+
+  describe '#build' do
+    subject { url_builder.build }
+
+    it 'includes the jwt param' do
+      expect(subject).to include('?jwt=')
+    end
+
+    context 'when the url already contains params' do
+      let(:url) { '/foo?expand=projects.issuetypes.fields' }
+
+      it 'includes the jwt param' do
+        expect(subject).to include('&jwt=')
+      end
+    end
+
+    context 'with a complete url' do
+      let(:url) { 'http://localhost:2990/rest/api/2/issue/createmeta' }
+
+      it 'includes the jwt param' do
+        expect(subject).to include('?jwt=')
+      end
+
+      it { is_expected.to start_with('/') }
+
+      it 'contains only one ?' do
+        expect(subject.count('?')).to eq(1)
+      end
+    end
+
+    context 'with a complete url containing a param' do
+      let(:url) do
+        'http://localhost:2990/rest/api/2/issue/createmeta?expand=projects.issuetypes.fields'
+      end
+
+      it 'includes the jwt param' do
+        expect(subject).to include('&jwt=')
+      end
+
+      it { is_expected.to start_with('/') }
+
+      it 'contains only one ?' do
+        expect(subject.count('?')).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Parsing of the url was not done correctly, resulting in two `?` signs in the url and the JWT token to not be recognised. 