### PR TITLE
Raise HTTPError if request is not a success

### DIFF
--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -28,6 +28,7 @@ module JIRA
                            client.request_client.options[:password])
 
         response = client.request_client.basic_auth_http_conn.request(request)
+        raise HTTPError, response unless response.is_a?(Net::HTTPSuccess)
 
         set_attrs(attrs, false)
         unless response.body.nil? || response.body.length < 2


### PR DESCRIPTION
`attachment#save!` doesn't raise a `JIRA::HTTPError` when there's an error.

When posting a file too large, JIRA responds with a 413 error (file too big). In this case, `save` raises a `JSON::ParserError` since it ignored the `HTTPError` and tried to parse the response.

Raising a `JIRA::HTTPError` (like in `lib/jira/request_client.rb`) allows `Base::save` to catch the exception.

I've tested it in my code and it seems to work well, but this is not well tested and the tests don't run.

Any side effect I haven't considered?

Can someone help me with the testing 

 but I'm not familiar enough with `RSpec` and `jira-ruby` to make the test pass.