### PR TITLE
Add support for proxy usernames/passwords

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -25,6 +25,8 @@ module JIRA
   #   :auth_type          => :oauth,
   #   :proxy_address      => nil,
   #   :proxy_port         => nil,
+  #   :proxy_username     => nil,
+  #   :proxy_password     => nil,
   #   :additional_cookies => nil,
   #   :default_headers    => {}
   #

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -43,7 +43,7 @@ module JIRA
 
     def http_conn(uri)
       if @options[:proxy_address]
-        http_class = Net::HTTP::Proxy(@options[:proxy_address], @options[:proxy_port] || 80)
+        http_class = Net::HTTP::Proxy(@options[:proxy_address], @options[:proxy_port] || 80, @options[:proxy_username], @options[:proxy_password])
       else
         http_class = Net::HTTP
       end

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -59,6 +59,16 @@ describe JIRA::HttpClient do
     { username: 'donaldduck', password: 'supersecret' }
   end
 
+  let(:proxy_client) do
+    options = JIRA::Client::DEFAULT_OPTIONS.merge(JIRA::HttpClient::DEFAULT_OPTIONS).merge(
+      proxy_address: 'proxyAddress',
+      proxy_port: 42,
+      proxy_username: 'proxyUsername',
+      proxy_password: 'proxyPassword'
+    )
+    JIRA::HttpClient.new(options)
+  end
+
   let(:response) do
     response = double('response')
     allow(response).to receive(:kind_of?).with(Net::HTTPSuccess).and_return(true)


### PR DESCRIPTION
`jira-ruby` didn't support proxies that require authentication, though `Net::HTTP::Proxy` does.  This adds an option to use such proxies.