### PR TITLE
gemspec: drop rubyforge_project, it is EOL

### DIFF
--- a/jira-ruby.gemspec
+++ b/jira-ruby.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.rubyforge_project = 'jira-ruby'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.