### PR TITLE
Ensure Ruby 2.5/2.6-based tests on CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 rvm:
     - 2.3
     - 2.4
+    - 2.5
+    - 2.6
     - ruby-head
 before_script:
     - rake jira:generate_public_cert


### PR DESCRIPTION
As Ruby 2.3 support has been finished in 2019-03, it might be optionally considered to remove 2.3 😄 