### PR TITLE
Drop CI for ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-    - 2.3
     - 2.4
     - ruby-head
 before_script:


### PR DESCRIPTION
Support of Ruby 2.3 has ended

https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/