### PR TITLE
Default HttpClient basic auth credentials to nil

### DIFF
--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -6,8 +6,8 @@ require 'uri'
 module JIRA
   class HttpClient < RequestClient
     DEFAULT_OPTIONS = {
-      username: '',
-      password: ''
+      username: nil,
+      password: nil
     }.freeze
 
     attr_reader :options
@@ -18,7 +18,7 @@ module JIRA
     end
 
     def make_cookie_auth_request
-      body = { username: @options[:username], password: @options[:password] }.to_json
+      body = { username: @options[:username].to_s, password: @options[:password].to_s }.to_json
       @options.delete(:username)
       @options.delete(:password)
       make_request(:post, @options[:context_path] + '/rest/auth/1/session', body, 'Content-Type' => 'application/json')


### PR DESCRIPTION
In my quest to get [OAuth 2.0](https://developer.atlassian.com/cloud/jira/platform/oauth-2-authorization-code-grants-3lo-for-apps/) functionality working by configuring the basic `HttpClient` I encountered some unexpected behaviour.

```ruby
JIRA::Client.new(
  auth_type: :basic,
  site: 'https://api.atlassian.com/ex/jira',
  context_path: "/ex/jira/#{integration.account_id}",
  default_headers: {
    'Authorization' => "Bearer #{integration.token}"
  }
)
```

I assumed that if I didn't pass a `username`/`password`, it would not set the basic auth header in the request. Instead I had to explicitly set the `username`/`password` to `nil`.

The other option would be to leave the defaults as empty strings but change the check to something like `!@options[:username].to_s.empty?`