### PR TITLE
Remove duplicate method definition in client.rb

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -203,10 +203,6 @@ module JIRA
       JIRA::Resource::RemotelinkFactory.new(self)
     end
 
-    def Sprint
-      JIRA::Resource::SprintFactory.new(self)
-    end
-
     def Agile
       JIRA::Resource::AgileFactory.new(self)
     end


### PR DESCRIPTION
method Sprint was duplicated in lib/jira/client.rb