### PR TITLE
Set explicit ruby versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
     - 2.4
     - 2.5
     - 2.6
-    - ruby-head
+    - 2.7
 before_script:
     - rake jira:generate_public_cert
 script: bundle exec rake spec


### PR DESCRIPTION
ruby-head is currently at `2.8.0dev` when 2.7 has just been released, I think we should explicit the versions we want to test.