### PR TITLE
Fixes Sprint::find to use context_path correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pkg/*
 .DS_STORE
 doc
 .ruby-version
+
+.rakeTasks

--- a/lib/jira/resource/sprint.rb
+++ b/lib/jira/resource/sprint.rb
@@ -5,7 +5,7 @@ module JIRA
 
     class Sprint < JIRA::Base
       def self.find(client, key)
-        response = client.get("#{client.options[:site]}/rest/agile/1.0/sprint/#{key}")
+        response = client.get(agile_path(client, key))
         json = parse_json(response.body)
         client.Sprint.build(json)
       end
@@ -19,7 +19,7 @@ module JIRA
 
       def add_issue(issue)
         request_body = { issues: [issue.id] }.to_json
-        response = client.post(client.options[:site] + "/rest/agile/1.0/sprint/#{id}/issue", request_body)
+        response = client.post("#{agile_path}/issue", request_body)
         true
       end
 
@@ -47,8 +47,8 @@ module JIRA
       end
 
       def get_sprint_details
-        search_url = client.options[:site] + '/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=' +
-                     rapidview_id.to_s + '&sprintId=' + id.to_s
+        search_url =
+          "#{client.options[:site]}#{client.options[:client_path]}/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=#{rapidview_id}&sprintId=#{id}"
         begin
           response = client.get(search_url)
         rescue StandardError
@@ -76,12 +76,12 @@ module JIRA
 
       def save(attrs = {}, _path = nil)
         attrs = @attrs if attrs.empty?
-        super(attrs, agile_url)
+        super(attrs, agile_path)
       end
 
       def save!(attrs = {}, _path = nil)
         attrs = @attrs if attrs.empty?
-        super(attrs, agile_url)
+        super(attrs, agile_path)
       end
 
       # WORK IN PROGRESS
@@ -93,8 +93,12 @@ module JIRA
 
       private
 
-      def agile_url
-        "#{client.options[:site]}/rest/agile/1.0/sprint/#{id}"
+      def agile_path
+        self.class.agile_path(client, id)
+      end
+
+      def self.agile_path(client, key)
+        "#{client.options[:context_path]}/rest/agile/1.0/sprint/#{key}"
       end
     end
   end

--- a/spec/jira/resource/sprint_spec.rb
+++ b/spec/jira/resource/sprint_spec.rb
@@ -1,12 +1,25 @@
 require 'spec_helper'
 
 describe JIRA::Resource::Sprint do
-  describe 'peristence' do
-    let(:sprint) { described_class.new(client) }
-    let(:client) { double('Client', options: { site: 'https://foo.bar.com' }) }
+  let(:client) do
+    client = double(options: { site: 'https://foo.bar.com', context_path: '/jira' })
+    allow(client).to receive(:Sprint).and_return(JIRA::Resource::SprintFactory.new(client))
+    client
+  end
+  let(:sprint) { described_class.new(client) }
+  let(:agile_sprint_path) { "#{sprint.client.options[:context_path]}/rest/agile/1.0/sprint/#{sprint.id}" }
 
+  describe '::find' do
+    let(:response) { double('Response', body: '{"some_detail":"some detail"}') }
+
+    it 'fetches the sprint from JIRA' do
+      expect(client).to receive(:get).with('/jira/rest/agile/1.0/sprint/111').and_return(response)
+      expect(JIRA::Resource::Sprint.find(client, '111')).to be_a(JIRA::Resource::Sprint)
+    end
+  end
+
+  describe 'peristence' do
     describe '#save' do
-      let(:agile_sprint_url) { "#{sprint.client.options[:site]}/rest/agile/1.0/sprint/#{sprint.id}" }
       let(:instance_attrs) { { start_date: '2016-06-01' } }
 
       before do
@@ -17,7 +30,7 @@ describe JIRA::Resource::Sprint do
         let(:given_attrs) { { start_date: '2016-06-10' } }
 
         it 'calls save on the super class with the given attributes & agile url' do
-          expect_any_instance_of(JIRA::Base).to receive(:save).with(given_attrs, agile_sprint_url)
+          expect_any_instance_of(JIRA::Base).to receive(:save).with(given_attrs, agile_sprint_path)
 
           sprint.save(given_attrs)
         end
@@ -25,7 +38,7 @@ describe JIRA::Resource::Sprint do
 
       context 'when attributes are not specified' do
         it 'calls save on the super class with the instance attributes & agile url' do
-          expect_any_instance_of(JIRA::Base).to receive(:save).with(instance_attrs, agile_sprint_url)
+          expect_any_instance_of(JIRA::Base).to receive(:save).with(instance_attrs, agile_sprint_path)
 
           sprint.save
         end
@@ -33,7 +46,7 @@ describe JIRA::Resource::Sprint do
 
       context 'when providing the path argument' do
         it 'ignores it' do
-          expect_any_instance_of(JIRA::Base).to receive(:save).with(instance_attrs, agile_sprint_url)
+          expect_any_instance_of(JIRA::Base).to receive(:save).with(instance_attrs, agile_sprint_path)
 
           sprint.save({}, 'mavenlink.com')
         end
@@ -41,7 +54,6 @@ describe JIRA::Resource::Sprint do
     end
 
     describe '#save!' do
-      let(:agile_sprint_url) { "#{sprint.client.options[:site]}/rest/agile/1.0/sprint/#{sprint.id}" }
       let(:instance_attrs) { { start_date: '2016-06-01' } }
 
       before do
@@ -52,7 +64,7 @@ describe JIRA::Resource::Sprint do
         let(:given_attrs) { { start_date: '2016-06-10' } }
 
         it 'calls save! on the super class with the given attributes & agile url' do
-          expect_any_instance_of(JIRA::Base).to receive(:save!).with(given_attrs, agile_sprint_url)
+          expect_any_instance_of(JIRA::Base).to receive(:save!).with(given_attrs, agile_sprint_path)
 
           sprint.save!(given_attrs)
         end
@@ -60,7 +72,7 @@ describe JIRA::Resource::Sprint do
 
       context 'when attributes are not specified' do
         it 'calls save! on the super class with the instance attributes & agile url' do
-          expect_any_instance_of(JIRA::Base).to receive(:save!).with(instance_attrs, agile_sprint_url)
+          expect_any_instance_of(JIRA::Base).to receive(:save!).with(instance_attrs, agile_sprint_path)
 
           sprint.save!
         end
@@ -68,7 +80,7 @@ describe JIRA::Resource::Sprint do
 
       context 'when providing the path argument' do
         it 'ignores it' do
-          expect_any_instance_of(JIRA::Base).to receive(:save!).with(instance_attrs, agile_sprint_url)
+          expect_any_instance_of(JIRA::Base).to receive(:save!).with(instance_attrs, agile_sprint_path)
 
           sprint.save!({}, 'mavenlink.com')
         end


### PR DESCRIPTION
Original code ignored client#options[:context_path].  This addresses the issue.  Have also added an RSpec to test that the URL is correctly formed.  All tests pass.

I use RubyMine which has automatically created a .rakeTasks - have added to the .gitignore.  Feel free to remove from the pull request.
