### PR TITLE
Fix transition issue

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -120,8 +120,8 @@ client.Issue.jql(a_normal_jql_search, max_results: 500)
 #
 # # Transition an issue
 # # -------------------
-# issue_transition = issue.transitions.build
-# issue_transition.save!('transition' => {'id' => transition_id})
+# issue_transition = underlying_jira.transitions.all.find { |t| t.name == "Transition" }
+# issue_transition.save('transition' => { 'id' => transition.id })
 #
 # # Change assignee
 # # -------------------

--- a/lib/jira/resource/sprint.rb
+++ b/lib/jira/resource/sprint.rb
@@ -48,7 +48,7 @@ module JIRA
 
       def get_sprint_details
         search_url =
-          "#{client.options[:site]}#{client.options[:client_path]}/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=#{rapidview_id}&sprintId=#{id}"
+          "#{client.options[:site]}#{client.options[:client_path]}/rest/agile/1.0/sprint/#{id}"
         begin
           response = client.get(search_url)
         rescue StandardError
@@ -56,22 +56,10 @@ module JIRA
         end
         json = self.class.parse_json(response.body)
 
-        @start_date = Date.parse(json['sprint']['startDate']) unless json['sprint']['startDate'] == 'None'
-        @end_date = Date.parse(json['sprint']['endDate']) unless json['sprint']['endDate'] == 'None'
-        @completed_date = Date.parse(json['sprint']['completeDate']) unless json['sprint']['completeDate'] == 'None'
+        @start_date = json['sprint']['startDate'] && Date.parse(json['sprint']['startDate'])
+        @end_date = json['sprint']['endDate'] && Date.parse(json['sprint']['endDate'])
+        @completed_date = json['sprint']['completeDate'] && Date.parse(json['sprint']['completeDate'])
         @sprint_report = client.SprintReport.build(json['contents'])
-      end
-
-      def rapidview_id
-        return @attrs['rapidview_id'] if @attrs['rapidview_id']
-        search_url = client.options[:site] + '/secure/GHGoToBoard.jspa?sprintId=' + id.to_s
-        begin
-          response = client.get(search_url)
-        rescue JIRA::HTTPError => error
-          return unless error.response.instance_of? Net::HTTPFound
-          rapid_view_match = /rapidView=(\d+)&/.match(error.response['location'])
-          @attrs['rapidview_id'] = rapid_view_match[1] unless rapid_view_match.nil?
-        end
       end
 
       def save(attrs = {}, _path = nil)

--- a/lib/jira/resource/transition.rb
+++ b/lib/jira/resource/transition.rb
@@ -24,6 +24,19 @@ module JIRA
           issue.transitions.build(transition)
         end
       end
+
+      # Saves the specified resource attributes by sending either a POST or PUT
+      # request to JIRA, depending on resource.new_record?
+      #
+      # Accepts an attributes hash of the values to be saved.  Will throw a
+      # JIRA::HTTPError if the request fails (response is not HTTP 2xx).
+      def save!(attrs, path = nil)
+        path = "#{client.options[:site]}#{client.options[:context]}/rest/api/2/issue/#{self.issue_id}/transitions"
+        response = client.send(:post, path, attrs.to_json)
+        set_attrs_from_response(response)
+        @expanded = false
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
I found two issues when trying to use jira-ruby to transition an issue:

1)  The example provided in the example.rb file does not work.  What one needs
is a list of available transitions given the current state of the JIRA.  issue.transitions.all does this.  It provides an array that
one can then look through to find the appropriate Id of the transition one wants to make.

2) Transition was using the default Base#save.  However this does not generate the correct URL.  It generates a URL in the form PUT  https://jira-hostt/rest/api/2/issue/13322/transitions/34 with a JSON payload.  What JIRA requires  is a URL of the form: POST https://jira-hostt/rest/api/2/issue/13322/transitions with the correct JSON payload.   This commit fixes this issue.
