### PR TITLE
Add read_timeout to accepted options

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -31,6 +31,7 @@ module JIRA
   #   :additional_cookies => nil,
   #   :default_headers    => {},
   #   :use_client_cert    => false,
+  #   :read_timeout       => nil,
   #   :http_debug         => false,
   #   :shared_secret      => nil
   #
@@ -75,6 +76,7 @@ module JIRA
       :additional_cookies,
       :default_headers,
       :use_client_cert,
+      :read_timeout,
       :http_debug,
       :issuer,
       :base_url,


### PR DESCRIPTION
It is used in http_client, and the example in README uses it.