### PR TITLE
Add_Cert_and_key_options

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -34,7 +34,9 @@ module JIRA
   #   :use_client_cert    => false,
   #   :read_timeout       => nil,
   #   :http_debug         => false,
-  #   :shared_secret      => nil
+  #   :shared_secret      => nil,
+  #   :cert_path          => nil,
+  #   :key_path           => nil
   #
   # See the JIRA::Base class methods for all of the available methods on these accessor
   # objects.
@@ -82,7 +84,9 @@ module JIRA
       :http_debug,
       :issuer,
       :base_url,
-      :shared_secret
+      :shared_secret,
+      :cert_path,
+      :key_path
     ].freeze
 
     DEFAULT_OPTIONS = {


### PR DESCRIPTION
The `DEFINED_OPTIONS` constant is missing `cert_path` and `key_path` making impossible to verify client's ssl files.