### PR TITLE
Adding support for ssl client certificate and key text based

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -34,7 +34,9 @@ module JIRA
   #   :use_client_cert    => false,
   #   :read_timeout       => nil,
   #   :http_debug         => false,
-  #   :shared_secret      => nil
+  #   :shared_secret      => nil,
+  #   :ssl_client_cert    => nil,
+  #   :ssl_client_key     => nil
   #
   # See the JIRA::Base class methods for all of the available methods on these accessor
   # objects.
@@ -82,7 +84,9 @@ module JIRA
       :http_debug,
       :issuer,
       :base_url,
-      :shared_secret
+      :shared_secret,
+      :ssl_client_cert,
+      :ssl_client_key
     ].freeze
 
     DEFAULT_OPTIONS = {
@@ -106,10 +110,11 @@ module JIRA
       raise ArgumentError, "Unknown option(s) given: #{unknown_options}" unless unknown_options.empty?
 
       if options[:use_client_cert]
-        raise ArgumentError, 'Options: :cert_path must be set when :use_client_cert is true' unless @options[:cert_path]
-        raise ArgumentError, 'Options: :key_path must be set when :use_client_cert is true' unless @options[:key_path]
-        @options[:cert] = OpenSSL::X509::Certificate.new(File.read(@options[:cert_path]))
-        @options[:key] = OpenSSL::PKey::RSA.new(File.read(@options[:key_path]))
+        @options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(File.read(@options[:cert_path])) if @options[:cert_path]
+        @options[:ssl_client_key] = OpenSSL::PKey::RSA.new(File.read(@options[:key_path])) if @options[:key_path]
+
+        raise ArgumentError, 'Options: :cert_path or :ssl_client_cert must be set when :use_client_cert is true' unless @options[:ssl_client_cert]
+        raise ArgumentError, 'Options: :key_path or :ssl_client_key must be set when :use_client_cert is true' unless @options[:ssl_client_key]
       end
 
       case options[:auth_type]

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -53,8 +53,8 @@ module JIRA
       http_conn = http_class.new(uri.host, uri.port)
       http_conn.use_ssl = @options[:use_ssl]
       if @options[:use_client_cert]
-        http_conn.cert = @options[:cert]
-        http_conn.key = @options[:key]
+        http_conn.cert = @options[:ssl_client_cert]
+        http_conn.key = @options[:ssl_client_key]
       end
       http_conn.verify_mode = @options[:ssl_verify_mode]
       http_conn.ssl_version = @options[:ssl_version] if @options[:ssl_version]

--- a/spec/jira/client_spec.rb
+++ b/spec/jira/client_spec.rb
@@ -59,6 +59,19 @@ RSpec.shared_examples 'Client Common Tests' do
       expect(subject.Project.find('123')).to eq(find_result)
     end
   end
+
+  describe 'SSL client options' do
+    context 'without certificate and key' do
+      let(:options) { { use_client_cert: true } }
+      subject { JIRA::Client.new(options) }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_exception(ArgumentError, 'Options: :cert_path or :ssl_client_cert must be set when :use_client_cert is true')
+        options[:ssl_client_cert] = '<cert></cert>'
+        expect { subject }.to raise_exception(ArgumentError, 'Options: :key_path or :ssl_client_key must be set when :use_client_cert is true')
+      end
+    end
+  end
 end
 
 RSpec.shared_examples 'HttpClient tests' do

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -280,8 +280,8 @@ describe JIRA::HttpClient do
     expect(http_conn).to receive(:use_ssl=).with(basic_client.options[:use_ssl])
     expect(http_conn).to receive(:verify_mode=).with(basic_client.options[:ssl_verify_mode])
     expect(http_conn).to receive(:read_timeout=).with(basic_client.options[:read_timeout])
-    expect(http_conn).to receive(:cert=).with(basic_client_cert_client.options[:cert])
-    expect(http_conn).to receive(:key=).with(basic_client_cert_client.options[:key])
+    expect(http_conn).to receive(:cert=).with(basic_client_cert_client.options[:ssl_client_cert])
+    expect(http_conn).to receive(:key=).with(basic_client_cert_client.options[:ssl_client_key])
     expect(basic_client_cert_client.http_conn(uri)).to eq(http_conn)
   end
 


### PR DESCRIPTION
Currently ssl client certificate and key file paths are only supported for verification, this change provides the ability to pass down the cert and key as strings instead of reading from disk using the `ssl_client_cert` and `ssl_client_key` options.

File paths will override the strings in case they are provided too, also renaming `cert` and `key` options to have a more meaningful name.