### PR TITLE
Add use_cookies to the available options list

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -6,7 +6,7 @@ module JIRA
   # This class is the main access point for all JIRA::Resource instances.
   #
   # The client must be initialized with an options hash containing
-  # configuration options.  The available options are:
+  # configuration options. The available options are:
   #
   #   :site               => 'http://localhost:2990',
   #   :context_path       => '/jira',
@@ -29,6 +29,7 @@ module JIRA
   #   :proxy_port         => nil,
   #   :proxy_username     => nil,
   #   :proxy_password     => nil,
+  #   :use_cookies        => nil,
   #   :additional_cookies => nil,
   #   :default_headers    => {},
   #   :use_client_cert    => false,
@@ -79,6 +80,7 @@ module JIRA
       :proxy_port,
       :proxy_username,
       :proxy_password,
+      :use_cookies,
       :additional_cookies,
       :default_headers,
       :use_client_cert,


### PR DESCRIPTION
### Description

After 731ecd8, we throw an exception when passing an unknown option. I think we are missing `use_cookies`.

At the moment, the example [Configuring JIRA to use Cookie-Based Auth](https://github.com/sumoheavy/jira-ruby#configuring-jira-to-use-cookie-based-auth) from the README fails:

```ruby
$ pry
[1] pry(main)> require 'jira-ruby'
=> true
[2] pry(main)>
[3] pry(main)> options = {
[3] pry(main)*   :username           => 'username',
[3] pry(main)*   :password           => 'pass1234',
[3] pry(main)*   :site               => 'http://mydomain.atlassian.net:443/',
[3] pry(main)*   :context_path       => '',
[3] pry(main)*   :auth_type          => :cookie,  # Set cookie based authentication
[3] pry(main)*   :use_cookies        => true,     # Send cookies with each request
[3] pry(main)*   :additional_cookies => ['AUTH=vV7uzixt0SScJKg7'] # Optional cookies to send
[3] pry(main)*   # with each request
[3] pry(main)* }
=> {:username=>"username",
 :password=>"pass1234",
 :site=>"http://mydomain.atlassian.net:443/",
 :context_path=>"",
 :auth_type=>:cookie,
 :use_cookies=>true,
 :additional_cookies=>["AUTH=vV7uzixt0SScJKg7"]}
[4] pry(main)>
[5] pry(main)> client = JIRA::Client.new(options)
ArgumentError: Unknown option(s) given: [:use_cookies]
from /Users/arturo/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/jira-ruby-2.1.3/lib/jira/client.rb:114:in `initialize'
```

This adds `use_cookies` to the list of the available options.

Thanks.