### PR TITLE
Automate generation of rsa keys for integration tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ end
 
 desc 'Run RSpec tests'
 # RSpec::Core::RakeTask.new(:spec)
-RSpec::Core::RakeTask.new(:spec) do |task|
+RSpec::Core::RakeTask.new(:spec, [] => [:prepare]) do |task|
   task.rspec_opts = ['--color', '--format', 'doc']
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ desc 'Prepare and run rspec tests'
 task :prepare do
   rsa_key = File.expand_path('rsakey.pem')
   unless File.exist?(rsa_key)
-    raise 'rsakey.pem does not exist, tests will fail.  Run `rake jira:generate_public_cert` first'
+    Rake::Task['jira:generate_public_cert'].invoke
   end
 end
 


### PR DESCRIPTION
I was initially confused as to how to get the specs to pass cleanly before investigating #232.

These two small changes to the rake tasks should smooth that out:
- the `:prepare` task is now an explicit dependency of the `:spec` task so that it gets called even if someone doesn't notice the :test: task and invokes :spec independently; and
- the `:prepare` task now auto-invokes the `jira:generate_public_cert` task if the local keypair is missing, rather than failing with guidance.