### PR TITLE
ISSUE-232 feature flag addition of the oauth_token parameter

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -65,6 +65,7 @@ module JIRA
       :request_token_path,
       :authorize_path,
       :access_token_path,
+      :append_explicit_oauth_token_parameter,
       :private_key,
       :private_key_file,
       :rest_base_path,

--- a/lib/jira/oauth_client.rb
+++ b/lib/jira/oauth_client.rb
@@ -11,7 +11,8 @@ module JIRA
       access_token_path: '/plugins/servlet/oauth/access-token',
       private_key_file: 'rsakey.pem',
       consumer_key: nil,
-      consumer_secret: nil
+      consumer_secret: nil,
+      append_explicit_oauth_token_parameter: true
     }.freeze
 
     # This exception is thrown when the client is used before the OAuth access token
@@ -75,8 +76,9 @@ module JIRA
     end
 
     def make_request(http_method, url, body = '', headers = {})
-      # When using oauth_2legged we need to add an empty oauth_token parameter to every request.
-      if @options[:auth_type] == :oauth_2legged
+      # Apparently we don't need to add an empty oauth_token parameter to every request; feature flagged here
+      # with :append_explicit_oauth_token_parameter to allow backwards compatibility
+      if @options[:auth_type] == :oauth_2legged && @options[:append_explicit_oauth_token_parameter]
         oauth_params_str = 'oauth_token='
         uri = URI.parse(url)
         uri.query = if uri.query.to_s == ''


### PR DESCRIPTION
previously an empty `oauth_token` parameter was appended to the
query before sending it to jira when the `:auth_type` parameter
was set to `:oauth_2legged`, but it appears that oauth v0.5.5
is appending the actual value of `oauth_token` as a parameter

as a result the code which was appending an empty `oauth_token`
parameter was actually appending it to the existing `oauth_token`
value, thereby corrupting the token and resulting in a vague

    parameter_rejected (OAuth::Problem)

error. I had to look at the detail in the server
`atlassian-jira.log` file in order to see the actual problem.

in order to preserve behaviour and backwards compatibilty with
the previous release of the jira-ruby gem, this commit introduces
a new feature flag `:append_explicit_oauth_token_parameter` which
defaults to true, same as before, but can now be explicitly
toggled off to avoid corrupting the access token in this way.

using this commit I am able to query for jira issues via JQL
without my username and password but instead using client options
configured like this:

    oauth_options = {
      site: 'https://my.jir.com',
      context_path: '',
      auth_type: :oauth_2legged,
      private_key_file: File.absolute_path(File.join(__dir__, 'privatekey.pem')),
      consumer_key: 'oauthtest',
      append_explicit_oauth_token_parameter: false
    }

I welcome feedback on:
- the feature flag approach taken here;
- naming of the flag, if flagging is the correct approach to take;
- anything else I can do to maintain consistency in the codebase or otherwise improve this request.