### PR TITLE
Allow Attachment to have custom filename

### DIFF
--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -20,13 +20,14 @@ module JIRA
       end
 
       def save!(attrs, path = url)
-        file = attrs['file'] || attrs[:file] # Keep supporting 'file' parameter as a string for backward compatibility
+        # Keep supporting 'file' parameter as a string for backward
+        # compatibility
+        file      = attrs['file']    || attrs[:file]
+        name      = attrs['name']    || attrs[:name] || file
         mime_type = attrs[:mimeType] || 'application/binary'
-
-        headers = { 'X-Atlassian-Token' => 'nocheck' }
-        data = { 'file' => UploadIO.new(file, mime_type, file) }
-
-        response = client.post_multipart(path, data , headers)
+        headers   = { 'X-Atlassian-Token' => 'nocheck' }
+        data      = { 'file' => UploadIO.new(file, mime_type, name) }
+        response  = client.post_multipart(path, data, headers)
 
         set_attributes(attrs, response)
 

--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -32,6 +32,7 @@ module JIRA
         set_attributes(attrs, response)
 
         @expanded = false
+
         true
       end
 

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -134,5 +134,45 @@ describe JIRA::Resource::Attachment do
         expect(attachment.size).to eq 23_123
       end
     end
+
+    context 'when passing in a string value for file name' do
+      subject do
+        attachment.save!(file: path_to_file, 'name' => 'test.jpg')
+      end
+
+      it 'successfully update the attachment' do
+        subject
+
+        expect(attachment.filename).to eq 'test.jpg'
+        expect(attachment.mimeType).to eq 'image/jpeg'
+        expect(attachment.size).to eq 23_123
+      end
+    end
+
+    context 'when passing in a symbol value for file name' do
+      subject do
+        attachment.save!(file: path_to_file, name: 'test.jpg')
+      end
+
+      it 'successfully update the attachment' do
+        subject
+
+        expect(attachment.filename).to eq 'test.jpg'
+        expect(attachment.mimeType).to eq 'image/jpeg'
+        expect(attachment.size).to eq 23_123
+      end
+    end
+
+    context 'when passing in a no value for file name' do
+      subject { attachment.save!(file: path_to_file) }
+
+      it 'successfully update the attachment using default filename' do
+        subject
+
+        expect(attachment.filename).to eq 'picture.jpg'
+        expect(attachment.mimeType).to eq 'image/jpeg'
+        expect(attachment.size).to eq 23_123
+      end
+    end
   end
 end

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -136,6 +136,21 @@ describe JIRA::Resource::Attachment do
     end
 
     context 'when passing in a string value for file name' do
+      let(:response) do
+        double(
+          body: [
+            {
+              "id": 10_001,
+              "self": 'http://www.example.com/jira/rest/api/2.0/attachments/10000',
+              "filename": 'test.jpg',
+              "created": '2017-07-19T12:23:06.572+0000',
+              "size": 23_123,
+              "mimeType": 'image/jpeg'
+            }
+          ].to_json
+        )
+      end
+
       subject do
         attachment.save!(file: path_to_file, 'name' => 'test.jpg')
       end
@@ -144,12 +159,25 @@ describe JIRA::Resource::Attachment do
         subject
 
         expect(attachment.filename).to eq 'test.jpg'
-        expect(attachment.mimeType).to eq 'image/jpeg'
-        expect(attachment.size).to eq 23_123
       end
     end
 
     context 'when passing in a symbol value for file name' do
+      let(:response) do
+        double(
+          body: [
+            {
+              "id": 10_001,
+              "self": 'http://www.example.com/jira/rest/api/2.0/attachments/10000',
+              "filename": 'test.jpg',
+              "created": '2017-07-19T12:23:06.572+0000',
+              "size": 23_123,
+              "mimeType": 'image/jpeg'
+            }
+          ].to_json
+        )
+      end
+
       subject do
         attachment.save!(file: path_to_file, name: 'test.jpg')
       end
@@ -158,20 +186,6 @@ describe JIRA::Resource::Attachment do
         subject
 
         expect(attachment.filename).to eq 'test.jpg'
-        expect(attachment.mimeType).to eq 'image/jpeg'
-        expect(attachment.size).to eq 23_123
-      end
-    end
-
-    context 'when passing in a no value for file name' do
-      subject { attachment.save!(file: path_to_file) }
-
-      it 'successfully update the attachment using default filename' do
-        subject
-
-        expect(attachment.filename).to eq 'picture.jpg'
-        expect(attachment.mimeType).to eq 'image/jpeg'
-        expect(attachment.size).to eq 23_123
       end
     end
   end


### PR DESCRIPTION
The Attachment resource, as far as I can tell, did not allow the user to provide a custom filename. If given a tmp file, the tmp filename would be used, which was not ideal. This change allows for an optional `name` value in the options to provide a custom file name, falling back to the old code value of the `file` variable if it's missing. To stay in line with the `file` key being allowed to be either a string or a symbol, the `name` key allows the same.