### PR TITLE
HttpClient: Allow specifying ca_file

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -40,6 +40,7 @@ module JIRA
   #   :key_path           => nil,
   #   :ssl_client_cert    => nil,
   #   :ssl_client_key     => nil
+  #   :ca_file            => nil
   #
   # See the JIRA::Base class methods for all of the available methods on these accessor
   # objects.

--- a/lib/jira/http_client.rb
+++ b/lib/jira/http_client.rb
@@ -59,6 +59,7 @@ module JIRA
       http_conn.verify_mode = @options[:ssl_verify_mode]
       http_conn.ssl_version = @options[:ssl_version] if @options[:ssl_version]
       http_conn.read_timeout = @options[:read_timeout]
+      http_conn.ca_file = @options[:ca_file] if @options[:ca_file]
       http_conn
     end
 

--- a/spec/jira/http_client_spec.rb
+++ b/spec/jira/http_client_spec.rb
@@ -285,6 +285,11 @@ describe JIRA::HttpClient do
     expect(basic_client_cert_client.http_conn(uri)).to eq(http_conn)
   end
 
+  it 'can use a certificate authority file' do
+    client = JIRA::HttpClient.new(JIRA::Client::DEFAULT_OPTIONS.merge(ca_file: '/opt/custom.ca.pem'))
+    expect(client.http_conn(client.uri).ca_file).to eql('/opt/custom.ca.pem')
+  end
+
   it 'returns a http connection' do
     http_conn = double
     uri = double


### PR DESCRIPTION
I'm working in an environment where we have our own certificate
authority, and I need to pass a CA file. It doesn't look like there's
currently a way to do so.

I see a similar patch was submitted in
https://github.com/sumoheavy/jira-ruby/pull/279 and it was just
withdrawn because the submitter didn't need it anymore. Now that I'm
seeing a need, I wonder whether there is a possibility of adding it.

I see a monkey-patch solution being offered in
https://github.com/sumoheavy/jira-ruby/issues/140#issuecomment-196534011
but my colleagues are leery of monkey-patching.

I also see from my searches that perhaps setting the environment
variable SSL_CERT_FILE may be able to achieve this, but we're also a
little leery of an implicit reliance on the environment variable, and
think it's better to be able to explicitly specify the ca file.