### PR TITLE
Fix JIRA::OauthClient.request_token block passing to get_request_token

### DIFF
--- a/lib/jira/oauth_client.rb
+++ b/lib/jira/oauth_client.rb
@@ -46,7 +46,7 @@ module JIRA
     # Returns the current request token if it is set, else it creates
     # and sets a new token.
     def request_token(options = {}, *arguments, &block)
-      @request_token ||= get_request_token(options, *arguments, block)
+      @request_token ||= get_request_token(options, *arguments, &block)
     end
 
     # Sets the request token from a given token and secret.

--- a/spec/jira/oauth_client_spec.rb
+++ b/spec/jira/oauth_client_spec.rb
@@ -35,6 +35,26 @@ describe JIRA::OauthClient do
       expect(oauth_client.get_request_token).to eq(request_token)
     end
 
+    it 'could pre-process the response body in a block' do
+      response = Net::HTTPSuccess.new(1.0, '200', 'OK')
+      allow_any_instance_of(OAuth::Consumer).to receive(:request).and_return(response)
+      allow(response).to receive(:body).and_return('&oauth_token=token&oauth_token_secret=secret&password=top_secret')
+
+      result = oauth_client.request_token do |response_body|
+        CGI.parse(response_body).each_with_object({}) do |(k, v), h|
+          next if k == 'password'
+
+          h[k.strip.to_sym] = v.first
+        end
+      end
+
+      expect(result).to be_an_instance_of(OAuth::RequestToken)
+      expect(result.consumer).to eql(oauth_client.consumer)
+      expect(result.params[:oauth_token]).to eql('token')
+      expect(result.params[:oauth_token_secret]).to eql('secret')
+      expect(result.params[:password]).to be_falsey
+    end
+
     it 'allows setting the request token' do
       token = double
       expect(OAuth::RequestToken).to receive(:new).with(oauth_client.consumer, 'foo', 'bar').and_return(token)


### PR DESCRIPTION
I've noticed a subtle bug: the `&block` received by the `request_token` method was passed into `get_request_token` not as a block reference, which should have been `&block`, but as a mere `block` argument. 

Given the `OAuth::Consumer.get_request_token(request_options = {}, *arguments, &block)` calling contract, the passed `block` was arriving into the `*arguments` array, instead of being bound as the method's block, so the passed block was never been called.

I've added a test for ensuring the block is correctly being processed.