### PR TITLE
chore(gems): Upgrade to OAuth 1.x

### DIFF
--- a/jira-ruby.gemspec
+++ b/jira-ruby.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'atlassian-jwt'
   s.add_runtime_dependency 'multipart-post'
-  s.add_runtime_dependency 'oauth', '~> 0.5', '>= 0.5.0'
+  s.add_runtime_dependency 'oauth', '~> 1.0'
 
   # Development Dependencies
   s.add_development_dependency 'guard', '~> 2.13', '>= 2.13.0'


### PR DESCRIPTION
OAuth 0.6 goes EOL around April 2024. Move to 1.x.

From the bundler output when you install the current version of this gem you get:

> You have installed oauth version 0.6.2, congratulations!
> 
> Non-commercial support for the 0.6.x series will end by April, 2024.
> Please upgrade to 1.0.x as soon as possible! The only breaking change
> will be dropped support for Ruby 2.4, 2.5, and 2.6.