### PR TITLE
Add GitHub actions with newer ruby versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,31 @@
+name: Ruby
+
+on: [push]
+
+jobs:
+  test:
+    name: CI-tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: |
+          bundle exec rake jira:generate_public_cert
+          bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-rvm:
-    - 2.4
-    - 2.5
-    - 2.6
-    - 2.7
-before_script:
-    - rake jira:generate_public_cert
-script: bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JIRA API Gem
 
 [![Code Climate](https://codeclimate.com/github/sumoheavy/jira-ruby.svg)](https://codeclimate.com/github/sumoheavy/jira-ruby)
+[![Build Status](https://github.com/sumoheavy/jira-ruby/actions/workflows/CI.yml/badge.svg)](https://github.com/sumoheavy/jira-ruby/actions/workflows/CI.yml)
 
 This gem provides access to the Atlassian JIRA REST API.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # JIRA API Gem
 
 [![Code Climate](https://codeclimate.com/github/sumoheavy/jira-ruby.svg)](https://codeclimate.com/github/sumoheavy/jira-ruby)
-[![Build Status](https://travis-ci.org/sumoheavy/jira-ruby.svg?branch=master)](https://travis-ci.org/sumoheavy/jira-ruby)
 
 This gem provides access to the Atlassian JIRA REST API.
 


### PR DESCRIPTION
# Changes

## Summary
- Replaced Travis CI for Github Actions CI
- Updated README

In order to continue doing maintenance and also verify the consistency of the gem, having a CI which is working properly with the newer Ruby versions is a good step ahead 👍🙂

# Disclaimer
I didn't add `Ruby 3.2` to the CI since it is throwing some errors while running the specs, I'll take a look at it when I have some time, but I just wanted to comment it in case that someone want to contribute there.

# Related Issue
https://github.com/sumoheavy/jira-ruby/issues/408
