### PR TITLE
Multipart default headers

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -291,7 +291,7 @@ module JIRA
 
     def post_multipart(path, file, headers = {})
       puts "post multipart: #{path} - [#{file}]" if @http_debug
-      @request_client.request_multipart(path, file, headers)
+      @request_client.request_multipart(path, file, merge_default_headers(headers))
     end
 
     def put(path, body = '', headers = {})

--- a/lib/jira/resource/attachment.rb
+++ b/lib/jira/resource/attachment.rb
@@ -24,7 +24,7 @@ module JIRA
         mime_type = attrs[:mimeType] || 'application/binary'
 
         headers = { 'X-Atlassian-Token' => 'nocheck' }
-        data = { 'file' => UploadIO.new(file, mime_type, file) }
+        data = { 'file' => Multipart::Post::UploadIO.new(file, mime_type, file) }
 
         response = client.post_multipart(path, data , headers)
 

--- a/spec/data/files/short.txt
+++ b/spec/data/files/short.txt
@@ -1,0 +1,1 @@
+short text

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -59,38 +59,6 @@ describe JIRA::Resource::Attachment do
     end
   end
 
-  describe '#save' do
-    subject { attachment.save('file' => path_to_file) }
-    let(:path_to_file) { './spec/mock_responses/issue.json' }
-    let(:response) do
-      double(
-        body: [
-          {
-            "id": 10_001,
-            "self": 'http://www.example.com/jira/rest/api/2.0/attachments/10000',
-            "filename": 'picture.jpg',
-            "created": '2017-07-19T12:23:06.572+0000',
-            "size": 23_123,
-            "mimeType": 'image/jpeg'
-          }
-        ].to_json
-      )
-    end
-    let(:issue) { JIRA::Resource::Issue.new(client) }
-
-    before do
-      allow(client).to receive(:post_multipart).and_return(response)
-    end
-
-    it 'successfully update the attachment' do
-      subject
-
-      expect(attachment.filename).to eq 'picture.jpg'
-      expect(attachment.mimeType).to eq 'image/jpeg'
-      expect(attachment.size).to eq 23_123
-    end
-  end
-
   context 'when there is a local file' do
     let(:file_name) { 'short.txt' }
     let(:file_size) { 11 }
@@ -111,6 +79,22 @@ describe JIRA::Resource::Attachment do
       )
     end
     let(:issue) { JIRA::Resource::Issue.new(client) }
+
+    describe '#save' do
+      subject { attachment.save('file' => path_to_file) }
+
+      before do
+        allow(client).to receive(:post_multipart).and_return(response)
+      end
+
+      it 'successfully update the attachment' do
+        subject
+
+        expect(attachment.filename).to eq file_name
+        expect(attachment.mimeType).to eq file_mime_type
+        expect(attachment.size).to eq file_size
+      end
+    end
 
     describe '#save' do
       context 'when using custom client headers' do
@@ -137,9 +121,7 @@ describe JIRA::Resource::Attachment do
 
         end
       end
-    end
 
-    describe '#save!' do
       subject { attachment.save!('file' => path_to_file) }
 
       before do

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -94,9 +94,6 @@ describe JIRA::Resource::Attachment do
         expect(attachment.mimeType).to eq file_mime_type
         expect(attachment.size).to eq file_size
       end
-    end
-
-    describe '#save' do
       context 'when using custom client headers' do
         subject(:bearer_attachment) do
           JIRA::Resource::Attachment.new(
@@ -122,7 +119,10 @@ describe JIRA::Resource::Attachment do
         end
       end
 
-      subject { attachment.save!('file' => path_to_file) }
+    end
+
+    describe '#save!' do
+    subject { attachment.save!('file' => path_to_file) }
 
       before do
         allow(client).to receive(:post_multipart).and_return(response)

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -115,7 +115,7 @@ describe JIRA::Resource::Attachment do
         end
 
         it 'passes the custom headers' do
-          expect(bearer_client.request_client).to receive(:request_multipart).with("/jira/rest/api/2/issue//attachments", anything, merged_headers).and_return(response)
+          expect(bearer_client.request_client).to receive(:request_multipart).with(anything, anything, merged_headers).and_return(response)
 
           bearer_attachment.save('file' => path_to_file)
 

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -166,7 +166,7 @@ describe JIRA::Resource::Attachment do
         end
 
         it 'passes the custom headers' do
-          expect(bearer_client.request_client).to receive(:request_multipart).with("/jira/rest/api/2/issue/attachments", anything, merged_headers).and_return(response)
+          expect(bearer_client.request_client).to receive(:request_multipart).with(anything, anything, merged_headers).and_return(response)
 
           bearer_attachment.save!('file' => path_to_file)
 

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -157,7 +157,6 @@ describe JIRA::Resource::Attachment do
     end
     let(:issue) { JIRA::Resource::Issue.new(client) }
 
-    # anything
     describe '#save!' do
       context 'when using custom client headers' do
         subject(:bearer_attachment) do

--- a/spec/jira/resource/attachment_spec.rb
+++ b/spec/jira/resource/attachment_spec.rb
@@ -91,51 +91,6 @@ describe JIRA::Resource::Attachment do
     end
   end
 
-  describe '#save!' do
-    subject { attachment.save!('file' => path_to_file) }
-
-    let(:path_to_file) { './spec/mock_responses/issue.json' }
-    let(:response) do
-      double(
-        body: [
-          {
-            "id": 10_001,
-            "self": 'http://www.example.com/jira/rest/api/2.0/attachments/10000',
-            "filename": 'picture.jpg',
-            "created": '2017-07-19T12:23:06.572+0000',
-            "size": 23_123,
-            "mimeType": 'image/jpeg'
-          }
-        ].to_json
-      )
-    end
-    let(:issue) { JIRA::Resource::Issue.new(client) }
-
-    before do
-      allow(client).to receive(:post_multipart).and_return(response)
-    end
-
-    it 'successfully update the attachment' do
-      subject
-
-      expect(attachment.filename).to eq 'picture.jpg'
-      expect(attachment.mimeType).to eq 'image/jpeg'
-      expect(attachment.size).to eq 23_123
-    end
-
-    context 'when passing in a symbol as file key' do
-      subject { attachment.save!(file: path_to_file) }
-
-      it 'successfully update the attachment' do
-        subject
-
-        expect(attachment.filename).to eq 'picture.jpg'
-        expect(attachment.mimeType).to eq 'image/jpeg'
-        expect(attachment.size).to eq 23_123
-      end
-    end
-  end
-
   context 'when there is a local file' do
     let(:file_name) { 'short.txt' }
     let(:file_size) { 11 }
@@ -157,7 +112,7 @@ describe JIRA::Resource::Attachment do
     end
     let(:issue) { JIRA::Resource::Issue.new(client) }
 
-    describe '#save!' do
+    describe '#save' do
       context 'when using custom client headers' do
         subject(:bearer_attachment) do
           JIRA::Resource::Attachment.new(
@@ -174,6 +129,60 @@ describe JIRA::Resource::Attachment do
         let(:merged_headers) do
           {"Accept"=>"application/json", "X-Atlassian-Token"=>"nocheck"}.merge(default_headers_given)
         end
+
+        it 'passes the custom headers' do
+          expect(bearer_client.request_client).to receive(:request_multipart).with("/jira/rest/api/2/issue//attachments", anything, merged_headers).and_return(response)
+
+          bearer_attachment.save('file' => path_to_file)
+
+        end
+      end
+    end
+
+    describe '#save!' do
+      subject { attachment.save!('file' => path_to_file) }
+
+      before do
+        allow(client).to receive(:post_multipart).and_return(response)
+      end
+
+      it 'successfully update the attachment' do
+        subject
+
+        expect(attachment.filename).to eq file_name
+        expect(attachment.mimeType).to eq file_mime_type
+        expect(attachment.size).to eq file_size
+      end
+
+      context 'when passing in a symbol as file key' do
+        subject { attachment.save!(file: path_to_file) }
+
+        it 'successfully update the attachment' do
+          subject
+
+          expect(attachment.filename).to eq file_name
+          expect(attachment.mimeType).to eq file_mime_type
+          expect(attachment.size).to eq file_size
+        end
+      end
+
+      context 'when using custom client headers' do
+        subject(:bearer_attachment) do
+          JIRA::Resource::Attachment.new(
+            bearer_client,
+            issue: JIRA::Resource::Issue.new(bearer_client),
+            attrs: { 'author' => { 'foo' => 'bar' } }
+          )
+        end
+        let(:default_headers_given) { { 'authorization' => "Bearer 83CF8B609DE60036A8277BD0E96135751BBC07EB234256D4B65B893360651BF2" } }
+        let(:bearer_client) do
+          JIRA::Client.new(username: 'username', password: 'password', auth_type: :basic, use_ssl: false,
+                           default_headers: default_headers_given )
+        end
+        let(:merged_headers) do
+          {"Accept"=>"application/json", "X-Atlassian-Token"=>"nocheck"}.merge(default_headers_given)
+        end
+
         it 'passes the custom headers' do
           expect(bearer_client.request_client).to receive(:request_multipart).with("/jira/rest/api/2/issue/attachments", anything, merged_headers).and_return(response)
 


### PR DESCRIPTION
I could not upload attachments onto issues.  I got a response that I did not have permissions to view the issue.
However, I found it was a bug that mulitpart posts were not passing the default headers from the client.
I am using OAuth 2.0, passing the Jira OAuth Access Token as a bearer token header.

This PR:
1. Fixes passing default headers with multipart posts.
2. Replaces the deprecated alias UploadIO with Multipart::Post::UploadIO.