### PR TITLE
Allow adding multiple issues

### DIFF
--- a/lib/jira/resource/sprint.rb
+++ b/lib/jira/resource/sprint.rb
@@ -18,7 +18,11 @@ module JIRA
       end
 
       def add_issue(issue)
-        request_body = { issues: [issue.id] }.to_json
+        add_issues([issue.id])
+      end
+
+      def add_issues(issues)
+        request_body = { issues: issues }.to_json
         response = client.post("#{agile_path}/issue", request_body)
         true
       end

--- a/lib/jira/resource/sprint.rb
+++ b/lib/jira/resource/sprint.rb
@@ -18,12 +18,13 @@ module JIRA
       end
 
       def add_issue(issue)
-        add_issues([issue.id])
+        add_issues( [ issue ])
       end
 
       def add_issues(issues)
-        request_body = { issues: issues }.to_json
-        response = client.post("#{agile_path}/issue", request_body)
+        issue_ids = issues.map{ |issue| issue.id }
+        request_body = { issues: issue_ids }.to_json
+        client.post("#{agile_path}/issue", request_body)
         true
       end
 

--- a/spec/jira/resource/sprint_spec.rb
+++ b/spec/jira/resource/sprint_spec.rb
@@ -86,5 +86,62 @@ describe JIRA::Resource::Sprint do
         end
       end
     end
+
+    context 'an issue exists' do
+      let(:issue_id) { 1001 }
+      let(:post_issue_path) do
+        described_class.agile_path(client, sprint.id)
+        "/jira/rest/agile/1.0/sprint//issue"
+      end
+      let(:issue) do
+        issue = double
+        allow(issue).to receive(:id).and_return(issue_id)
+        issue
+      end
+      let(:post_issue_input) do
+        {"issues":[issue.id]}
+      end
+
+
+      describe '#add_issu' do
+        context 'when an issue is passed' do
+
+          it 'posts with the issue id' do
+            expect(client).to receive(:post).with(post_issue_path, post_issue_input.to_json)
+
+            sprint.add_issue(issue)
+          end
+        end
+      end
+    end
+
+    context 'multiple issues exists' do
+      let(:issue_ids) { [ 1001, 1012 ] }
+      let(:post_issue_path) do
+        described_class.agile_path(client, sprint.id)
+        "/jira/rest/agile/1.0/sprint//issue"
+      end
+      let(:issues) do
+        issue_ids.map do |issue_id|
+          issue = double
+          allow(issue).to receive(:id).and_return(issue_id)
+          issue
+        end
+      end
+      let(:post_issue_input) do
+        {"issues": issue_ids}
+      end
+
+      describe '#add_issues' do
+        context 'when an issue is passed' do
+
+          it 'posts with the issue id' do
+            expect(client).to receive(:post).with(post_issue_path, post_issue_input.to_json)
+
+            sprint.add_issues(issues)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Addition of method for adding multiple issues.
Wrote test for [PR 390](https://github.com/sumoheavy/jira-ruby/pull/390/files).

@SimonMiaou This replaces PR 390 as an alternative allowing PR 390 to be closed.

