### PR TITLE
Change expect for raising to block from advice of deprecation warning.

### DIFF
--- a/spec/jira/base_spec.rb
+++ b/spec/jira/base_spec.rb
@@ -301,7 +301,7 @@ describe JIRA::Base do
       response = instance_double('Response', body: '{"errorMessages":["blah"]}', status: 400)
       allow(subject).to receive(:new_record?) { false }
       expect(client).to receive(:put).with('/foo/bar', '{"invalid_field":"foobar"}').and_raise(JIRA::HTTPError.new(response))
-      expect(-> { subject.save!('invalid_field' => 'foobar') }).to raise_error(JIRA::HTTPError)
+      expect{ subject.save!('invalid_field' => 'foobar') }.to raise_error(JIRA::HTTPError)
     end
   end
 
@@ -579,9 +579,9 @@ describe JIRA::Base do
     end
 
     it 'raises an exception when initialized without a belongs_to instance' do
-      expect(lambda {
+      expect{
         JIRA::Resource::BelongsToExample.new(client, attrs: { 'id' => '123' })
-      }).to raise_exception(ArgumentError, 'Required option :deadbeef missing')
+      }.to raise_exception(ArgumentError, 'Required option :deadbeef missing')
     end
 
     it 'returns the right url' do

--- a/spec/support/shared_examples/integration.rb
+++ b/spec/support/shared_examples/integration.rb
@@ -55,9 +55,9 @@ shared_examples 'a resource' do
     stub_request(:put, site_url + subject.url)
       .to_return(status: 405, body: '<html><body>Some HTML</body></html>')
     expect(subject.save('foo' => 'bar')).to be_falsey
-    expect(lambda do
+    expect do
       expect(subject.save!('foo' => 'bar')).to be_falsey
-    end).to raise_error(JIRA::HTTPError)
+    end.to raise_error(JIRA::HTTPError)
   end
 end
 
@@ -115,9 +115,9 @@ shared_examples 'a resource with a singular GET endpoint' do
   it 'handles a 404' do
     stub_request(:get, site_url + described_class.singular_path(client, '99999', prefix))
       .to_return(status: 404, body: '{"errorMessages":["' + class_basename + ' Does Not Exist"],"errors": {}}')
-    expect(lambda do
+    expect do
       client.send(class_basename).find('99999', options)
-    end).to raise_exception(JIRA::HTTPError)
+    end.to raise_exception(JIRA::HTTPError)
   end
 end
 
@@ -170,8 +170,8 @@ shared_examples 'a resource with a PUT endpoint that rejects invalid fields' do
     subject.fetch
 
     expect(subject.save('fields' => { 'invalid' => 'field' })).to be_falsey
-    expect(lambda do
+    expect do
       subject.save!('fields' => { 'invalid' => 'field' })
-    end).to raise_error(JIRA::HTTPError)
+    end.to raise_error(JIRA::HTTPError)
   end
 end


### PR DESCRIPTION
When running rspec, there are deprecation warnings which this PR fixes.