### PR TITLE
Raise rspec version upper limit for 2023-12 and add byebug

### DIFF
--- a/jira-ruby.gemspec
+++ b/jira-ruby.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec', '~> 4.6', '>= 4.6.5'
   s.add_development_dependency 'pry', '~> 0.10', '>= 0.10.3'
   s.add_development_dependency 'railties'
-  s.add_development_dependency 'rake', '~> 10.3', '>= 10.3.2'
+  s.add_development_dependency 'byebug', '~> 11.1'
+  s.add_development_dependency 'rake', '< 14.0', '>= 10.3.2'
   s.add_development_dependency 'rspec', '~> 3.0', '>= 3.0.0'
   s.add_development_dependency 'webmock', '~> 1.18', '>= 1.18.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'webmock/rspec'
 require 'pry'
+require 'byebug'
 
 Dir['./spec/support/**/*.rb'].each { |f| require f }
 


### PR DESCRIPTION
I checked the version numbers for the dependent gems for 2023 December.
The `rspec` version needed the upper limit raised.
I also added byebug because it is helpful to me when developing or writing tests.
