### PR TITLE
Initial preparations for v3.0.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: Ruby
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -10,14 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.3'
+          - '3.2'
           - '3.1'
-          - '3.0'
-          - '2.7'
-          - '2.6'
-          - '2.5'
-          - '2.4'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 group :development do
   gem 'guard'

--- a/jira-ruby.gemspec
+++ b/jira-ruby.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.licenses    = ['MIT']
   s.metadata    = { 'source_code_uri' => 'https://github.com/sumoheavy/jira-ruby' }
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 3.1.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
@@ -25,11 +25,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'oauth', '~> 1.0'
 
   # Development Dependencies
-  s.add_development_dependency 'guard', '~> 2.13', '>= 2.13.0'
-  s.add_development_dependency 'guard-rspec', '~> 4.6', '>= 4.6.5'
-  s.add_development_dependency 'pry', '~> 0.10', '>= 0.10.3'
+  s.add_development_dependency 'guard', '~> 2.18', '>= 2.18.1'
+  s.add_development_dependency 'guard-rspec', '~> 4.7', '>= 4.7.3'
+  s.add_development_dependency 'pry', '~> 0.14', '>= 0.14.3'
   s.add_development_dependency 'railties'
-  s.add_development_dependency 'rake', '~> 10.3', '>= 10.3.2'
-  s.add_development_dependency 'rspec', '~> 3.0', '>= 3.0.0'
+  s.add_development_dependency 'rake', '~> 13.2', '>= 13.2.1'
+  s.add_development_dependency 'rspec', '~> 3.0', '>= 3.13'
   s.add_development_dependency 'webmock', '~> 1.18', '>= 1.18.0'
 end


### PR DESCRIPTION
# Overview

The goal of this PR is to prepare some of the backward incompatible changes for the upcoming 3.0.0 release of the gem. It's honestly been a while since we've updated it, but I'm in a position where I can put more time into this. Thank you so much to everyone who continues to contribute and have been using the gem for all this time.

# Changes

There are a few main things that this covers, which include updates to supported versions of Ruby, updates to the Gemfile, and dependency updates.

## GitHub Actions

- Run tests on both `push` and `pull_request`: This will help preview tests in our PRs
- Dropping support for Ruby <= 3.0: It's going to be harder to support as dependencies and standards improve around the gem, and we don't want to hit a wall where updating would be incredibly difficult or require a complete rewrite
- Update to `actions/checkout@v4`: This updated the node runtime

## Gemfile & gemspec

- Using a secure rubygem source: It's been best to pull from https for a long time now, so I've updated that
- Updated some dependencies

# Notes
I'll push some other updates in separate requests, but so far I'm considering:
- Adding dependabot
- Updating webmock
- Adding coverage
- Adding some sane defaults for rubocop
- Adding rubocop to the GitHub Actions