### PR TITLE
Load Active Support's Object extensions

### DIFF
--- a/lib/jira/http_error.rb
+++ b/lib/jira/http_error.rb
@@ -1,4 +1,6 @@
 require 'forwardable'
+require 'active_support/core_ext/object'
+
 module JIRA
   class HTTPError < StandardError
     extend Forwardable


### PR DESCRIPTION
If `active_support/core_ext/object` was not already loaded and there is an http error, the following undefined method error would be raised:

```
/home/xxxx/.rvm/gems/ruby-3.2.2/gems/jira-ruby-2.3.0/lib/jira/http_error.rb:11:in `initialize': undefined method `presence' for "Bad Request":String (NoMethodError)

      @message = response.try(:message).presence || response.try(:body)
                                       ^^^^^^^^^
```

The `presence` method is defined by Active Support's Object extensions.

To reproduce this issue, in the root of the project repository, save the following code to a file (say `test.rb`):

```ruby
require 'jira-ruby'

response = Struct.new(:message, :body).new('my message', 'my body')

JIRA::HTTPError.new(response)
```

and then run with the following command run in the repository's root folder:

```shell
ruby -Ilib test.rb
```

This results in the following error:

```shell
/Users/couballj/SynologyDrive/Documents/Projects/jira-ruby/lib/jira/http_error.rb:11:in `initialize': undefined method `presence' for an instance of String (NoMethodError)

      @message = response.try(:message).presence || response.try(:body)
                                       ^^^^^^^^^
```

This PR adds the require statement to load these Active Support extensions.

After this change, there is no error when the above script is run.