### PR TITLE
Update tests for to_json

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: Ruby
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/spec/jira/base_spec.rb
+++ b/spec/jira/base_spec.rb
@@ -428,7 +428,7 @@ describe JIRA::Base do
 
     h       = { 'key' => subject }
     h_attrs = { 'key' => subject.attrs }
-    expect(h.to_json).to eq(h_attrs.to_json)
+    expect(h['key'].to_json).to eq(h_attrs['key'].to_json)
   end
 
   describe 'extract attrs from response' do


### PR DESCRIPTION
This is an update to the tests to support the change in https://github.com/sumoheavy/jira-ruby/pull/435/files. Introducing `active_support/core_ext/object` changes the behavior of `to_json` so we need to account for that.