### PR TITLE
#433 Remove link to deprecated Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 
 This gem provides access to the Atlassian JIRA REST API.
 
-## Slack
-
-Join our Slack channel! You can find us [here](https://jira-ruby-slackin.herokuapp.com/)
-
 ## Example usage
 
 # Jira Ruby API - Sample Usage


### PR DESCRIPTION
We are no longer using Slack, so I'm removing the link. Other documentation improvements coming shortly.