### PR TITLE
#430 Upgrade webmock and tests

### DIFF
--- a/jira-ruby.gemspec
+++ b/jira-ruby.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'railties'
   s.add_development_dependency 'rake', '~> 13.2', '>= 13.2.1'
   s.add_development_dependency 'rspec', '~> 3.0', '>= 3.13'
-  s.add_development_dependency 'webmock', '~> 1.18', '>= 1.18.0'
+  s.add_development_dependency 'webmock', '~> 3.23', '>= 3.23.0'
 end

--- a/spec/jira/client_spec.rb
+++ b/spec/jira/client_spec.rb
@@ -140,10 +140,12 @@ describe JIRA::Client do
     subject { JIRA::Client.new(username: 'foo', password: 'bar', auth_type: :basic) }
 
     before(:each) do
-      stub_request(:get, 'https://foo:bar@localhost:2990/jira/rest/api/2/project')
+      stub_request(:get, 'https://localhost:2990/jira/rest/api/2/project')
+        .with(headers: { 'Authorization' => "Basic #{Base64.strict_encode64('foo:bar').chomp}" })
         .to_return(status: 200, body: '[]', headers: {})
 
-      stub_request(:get, 'https://foo:badpassword@localhost:2990/jira/rest/api/2/project')
+      stub_request(:get, 'https://localhost:2990/jira/rest/api/2/project')
+      .with(headers: { 'Authorization' => "Basic #{Base64.strict_encode64('foo:badpassword').chomp}" })
         .to_return(status: 401, headers: {})
     end
 
@@ -157,16 +159,16 @@ describe JIRA::Client do
       expect(subject.options[:password]).to eq('bar')
     end
 
+    it 'only returns a true for #authenticated? once we have requested some data' do
+      expect(subject.authenticated?).to be_nil
+      expect(subject.Project.all).to be_empty
+      expect(subject.authenticated?).to be_truthy
+    end
+
     it 'fails with wrong user name and password' do
       bad_login = JIRA::Client.new(username: 'foo', password: 'badpassword', auth_type: :basic)
       expect(bad_login.authenticated?).to be_falsey
       expect { bad_login.Project.all }.to raise_error JIRA::HTTPError
-    end
-
-    it 'only returns a true for #authenticated? once we have requested some data' do
-      expect(subject.authenticated?).to be_falsey
-      expect(subject.Project.all).to be_empty
-      expect(subject.authenticated?).to be_truthy
     end
   end
 

--- a/spec/support/clients_helper.rb
+++ b/spec/support/clients_helper.rb
@@ -7,7 +7,7 @@ module ClientsHelper
     clients['http://localhost:2990'] = oauth_client
 
     basic_client = JIRA::Client.new(username: 'foo', password: 'bar', auth_type: :basic, use_ssl: false)
-    clients['http://foo:bar@localhost:2990'] = basic_client
+    clients['http://localhost:2990'] = basic_client
 
     clients.each do |site_url, client|
       yield site_url, client


### PR DESCRIPTION
# Overview

The goal of this pull request is to upgrade to webmock 3.x. There are a few changes necessary to accomplish this:
* Update webmock
* Update how we implement authenticated calls

# Notes

The number of tests reported will drop, due to what I can tell are duplicates running in v1. Looking at the examples below, you'll see that webmock v1.x was running the shared tests twice. This has been remedied.

## webmock v1.x
```
JIRA::Resource::Comment
  it should behave like a resource
    gracefully handles non-json responses
  it should behave like a resource with a collection GET endpoint
    should get the collection
  it should behave like a resource with a singular GET endpoint
    GETs a single resource
    builds and fetches a single resource
    handles a 404
  it should behave like a resource with a DELETE endpoint
    deletes a resource
  it should behave like a resource with a POST endpoint
    saves a new resource
  it should behave like a resource with a PUT endpoint
    saves an existing component
  it should behave like a resource
    gracefully handles non-json responses
  it should behave like a resource with a collection GET endpoint
    should get the collection
  it should behave like a resource with a singular GET endpoint
    GETs a single resource
    builds and fetches a single resource
    handles a 404
  it should behave like a resource with a DELETE endpoint
    deletes a resource
  it should behave like a resource with a POST endpoint
    saves a new resource
  it should behave like a resource with a PUT endpoint
    saves an existing component
```

## webmock v3.x
```
JIRA::Resource::Comment
  it should behave like a resource
    gracefully handles non-json responses
  it should behave like a resource with a collection GET endpoint
    should get the collection
  it should behave like a resource with a singular GET endpoint
    GETs a single resource
    builds and fetches a single resource
    handles a 404
  it should behave like a resource with a DELETE endpoint
    deletes a resource
  it should behave like a resource with a POST endpoint
    saves a new resource
  it should behave like a resource with a PUT endpoint
    saves an existing component
```