### PR TITLE
Fix personal access token usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,7 @@ api_token = API_TOKEN_OBTAINED_FROM_JIRA_UI
 options = {
   :site               => 'http://mydomain.atlassian.net:443/',
   :context_path       => '',
-  :username           => '<the email you sign-in to Jira>',
-  :password           => api_token,
+  :default_headers    => { 'Authorization' => "Bearer #{api_token}" },
   :auth_type          => :basic
 }
 


### PR DESCRIPTION
Hello, it took me a long time to figure out authorization via PAT. As a result, it turned out that the documentation contains an outdated usage example, although the information in the paragraph in front of it is valid.

I found that this is a known issue, so the PR probably closes #424