### PR TITLE
Remove OpenStruct usage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -178,9 +178,6 @@ Style/ClassAndModuleChildren:
 Style/MissingRespondToMissing:
   Enabled: false
 
-Style/OpenStructUse:
-  Enabled: false
-
 Style/OptionalBooleanParameter:
   Enabled: false
 

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'forwardable'
-require 'ostruct'
 
 module JIRA
   # This class is the main access point for all JIRA::Resource instances.
@@ -55,7 +54,7 @@ module JIRA
     #
     # The authenticated client instance returned by the respective client type
     # (Oauth, Basic)
-    attr_accessor :consumer, :request_client, :http_debug, :cache
+    attr_accessor :consumer, :request_client, :http_debug, :field_map_cache
 
     # The configuration options for this client instance
     attr_reader :options
@@ -164,8 +163,6 @@ module JIRA
       @http_debug = @options[:http_debug]
 
       @options.freeze
-
-      @cache = OpenStruct.new
     end
 
     def Project # :nodoc:

--- a/lib/jira/resource/field.rb
+++ b/lib/jira/resource/field.rb
@@ -21,7 +21,6 @@ module JIRA
 
       def self.map_fields(client)
         field_map = {}
-        field_map_reverse = {}
         fields = client.Field.all
 
         # two pass approach, so that a custom field with the same name
@@ -30,7 +29,6 @@ module JIRA
           next if f.custom
 
           name = safe_name(f.name)
-          field_map_reverse[f.id] = [f.name, name] # capture both the official name, and the mapped name
           field_map[name] = f.id
         end
 
@@ -44,23 +42,21 @@ module JIRA
                  else
                    safe_name(f.name)
                  end
-          field_map_reverse[f.id] = [f.name, name] # capture both the official name, and the mapped name
           field_map[name] = f.id
         end
 
-        client.cache.field_map_reverse = field_map_reverse # not sure where this will be used yet, but sure to be useful
-        client.cache.field_map = field_map
+        client.field_map_cache = field_map
       end
 
       def self.field_map(client)
-        client.cache.field_map
+        client.field_map_cache
       end
 
       def self.name_to_id(client, field_name)
         field_name = field_name.to_s
-        return field_name unless client.cache.field_map && client.cache.field_map[field_name]
+        return field_name unless client.field_map_cache && client.field_map_cache[field_name]
 
-        client.cache.field_map[field_name]
+        client.field_map_cache[field_name]
       end
 
       def respond_to?(method_name, _include_all = false)

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -41,7 +41,7 @@ describe JIRA::Resource::User do
 
       before do
         allow(client).to receive(:get)
-          .with('/rest/api/2/users/search?username=_&maxResults=1000') { OpenStruct.new(body: '["User1"]') }
+          .with('/rest/api/2/users/search?username=_&maxResults=1000') { double(body: '["User1"]') }
         allow(client).to receive_message_chain(:User, :build).with('users') { [] }
       end
 

--- a/spec/jira/resource/board_spec.rb
+++ b/spec/jira/resource/board_spec.rb
@@ -107,7 +107,7 @@ EOS
 
       context 'when there are multiple pages of results' do
         let(:result_1) do
-          OpenStruct.new(body: {
+          double(body: {
             'startAt' => 0,
             'maxResults' => 1,
             'total' => 2,
@@ -115,7 +115,7 @@ EOS
           }.to_json)
         end
         let(:result_2) do
-          OpenStruct.new(body: {
+          double(body: {
             'startAt' => 1,
             'maxResults' => 1,
             'total' => 2,
@@ -132,7 +132,7 @@ EOS
 
       context 'when there is only one page of results' do
         let(:result_1) do
-          OpenStruct.new(body: {
+          double(body: {
             'startAt' => 0,
             'maxResults' => 2,
             'total' => 2,

--- a/spec/jira/resource/field_spec.rb
+++ b/spec/jira/resource/field_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
 
 describe JIRA::Resource::Field do
-  let(:cache) { OpenStruct.new }
-
   let(:client) do
     client = double(options: { rest_base_path: '/jira/rest/api/2' })
     field = JIRA::Resource::FieldFactory.new(client)
     allow(client).to receive(:Field).and_return(field)
-    allow(client).to receive(:cache).and_return(cache)
+    allow(client).to receive(:field_map_cache).and_return(nil)
+    allow(client).to receive(:field_map_cache=)
     # info about all fields on the client
     allow(client.Field).to receive(:all).and_return([
                                                       described_class.new(client,

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -7,7 +7,7 @@ describe JIRA::Resource::Issue do
   let(:client) do
     client = double(options: { rest_base_path: '/jira/rest/api/2' })
     allow(client).to receive(:Field).and_return(JIRA::Resource::FieldFactory.new(client))
-    allow(client).to receive(:cache).and_return(OpenStruct.new)
+    allow(client).to receive(:field_map_cache).and_return(nil)
     client
   end
 

--- a/spec/jira/resource/status_spec.rb
+++ b/spec/jira/resource/status_spec.rb
@@ -4,7 +4,7 @@ describe JIRA::Resource::Status do
   let(:client) do
     client = double(options: { rest_base_path: '/jira/rest/api/2' })
     allow(client).to receive(:Field).and_return(JIRA::Resource::FieldFactory.new(client))
-    allow(client).to receive(:cache).and_return(OpenStruct.new)
+    allow(client).to receive(:field_map_cache).and_return(nil)
     client
   end
 


### PR DESCRIPTION
Loading the gem on Ruby 3.3.5 or 3.4.0-preview1 prints this warning:

    lib/jira-ruby.rb:53: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
    You can add ostruct to your Gemfile or gemspec to silence this warning.

OpenStruct is used to store two values (`field_map` and `field_map_reverse`) but only `field_map` was actually used, so we can store it directly in an instance variable and remove the dependency on OpenStruct.