### PR TITLE
Update to 3.0.0, remove beta label

### DIFF
--- a/lib/jira/version.rb
+++ b/lib/jira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JIRA
-  VERSION = '3.0.0.beta2'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
The latest version (3.0.0) has been beta for some time now, and with the latest update, I'm removing the beta tag and releasing it. All changes have been in the `master` branch since the before the first beta, and starts to move in a more modern direction, dropping old versions of Ruby, correcting numerous Rubocop issues, etc.