### PR TITLE
Remove CodeClimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # JIRA API Gem
 
-[![Code Climate](https://codeclimate.com/github/sumoheavy/jira-ruby.svg)](https://codeclimate.com/github/sumoheavy/jira-ruby)
 [![Build Status](https://github.com/sumoheavy/jira-ruby/actions/workflows/CI.yml/badge.svg)](https://github.com/sumoheavy/jira-ruby/actions/workflows/CI.yml)
 
 This gem provides access to the Atlassian JIRA REST API.


### PR DESCRIPTION
CodeClimate isn't available to us anymore so I'm removing the badge.