### PR TITLE
Prevent set_attrs deep merge from writing nested keys into top-level attrs

### DIFF
--- a/lib/jira/base.rb
+++ b/lib/jira/base.rb
@@ -396,6 +396,7 @@ module JIRA
       else
         hash.each do |k, v|
           if v.is_a?(Hash)
+            target[k] = {} unless target[k].is_a?(Hash)
             set_attrs(v, clobber, target[k])
           else
             target[k] = v

--- a/spec/jira/base_spec.rb
+++ b/spec/jira/base_spec.rb
@@ -339,6 +339,27 @@ describe JIRA::Base do
       subject.set_attrs({ 'foo' => { 'fum' => 'dum' } }, false)
       expect(subject.foo).to eq('bar' => 'baz', 'fum' => 'dum')
     end
+
+    it 'creates missing intermediate hashes instead of merging into the top level when clobber is false' do
+      subject.attrs = { 'id' => '10500', 'key' => 'REL-77', 'fields' => { 'summary' => 'x' } }
+      subject.set_attrs({ 'fields' => { 'project' => { 'key' => 'REL' } } }, false)
+      expect(subject.attrs['key']).to eq('REL-77')
+      expect(subject.attrs['fields']['project']['key']).to eq('REL')
+      expect(subject.attrs['fields']['summary']).to eq('x')
+    end
+
+    it 'deeply merges into an existing nested hash when clobber is false' do
+      subject.attrs = { 'fields' => { 'project' => { 'id' => '10000' }, 'summary' => 'x' } }
+      subject.set_attrs({ 'fields' => { 'project' => { 'key' => 'REL' } } }, false)
+      expect(subject.attrs['fields']['project']).to eq('id' => '10000', 'key' => 'REL')
+      expect(subject.attrs['fields']['summary']).to eq('x')
+    end
+
+    it 'replaces a non-hash value with the new hash when clobber is false' do
+      subject.attrs = { 'fields' => { 'project' => 'REL' } }
+      subject.set_attrs({ 'fields' => { 'project' => { 'key' => 'REL' } } }, false)
+      expect(subject.attrs['fields']['project']).to eq('key' => 'REL')
+    end
   end
 
   describe 'delete' do


### PR DESCRIPTION
Same root cause as #176, open since 2016. The review there asked for a test before merging, so this PR brings the tests, plus coverage for a second edge that patch misses.

`set_attrs(hash, false)` deep-merges into `@attrs`, but when the incoming hash has a nested hash under a key the resource doesn't have yet, the recursion gets `target[k]` = nil and the `target ||= @attrs` fallback sends the merge to the top level instead:

```ruby
issue.attrs = { 'id' => '10500', 'key' => 'REL-77', 'fields' => { 'summary' => 'x' } }
issue.set_attrs({ 'fields' => { 'project' => { 'key' => 'REL' } } }, false)
issue.attrs['key']               # => "REL", expected "REL-77"
issue.attrs['fields']['project'] # => nil, expected {"key"=>"REL"}
```

In practice you hit this through `save!`, which merges the request payload back into attrs. Any resource with sparse attrs is exposed, e.g. an issue built from a `/search/jql` result. In our app, saving fields onto an issue loaded from a search result overwrote the issue's own `key` with the project key, which broke every URL built from `issue.key` afterwards.

There's a second edge: when `target[k]` is a scalar and the incoming value is a hash, the recursion raises `IndexError: string not matched` (it indexes into a String). The #176 patch (`target[k] = {} if !target.key?(k) || target[k].nil?`) fixes the nil case but not this one.

The fix is one line: `target[k] = {} unless target[k].is_a?(Hash)` before recursing. It creates the missing intermediate hash, replaces a scalar being superseded by a hash, and confines the nil-target fallback to the initial call, which is what the "internal use only" comment on `target` intended.

Tests: three new examples in the `set_attrs` block of `base_spec.rb` — the repro above, a merge into an existing nested key to show unchanged behavior, and the scalar case. Full suite is green apart from the 78 pre-existing failures in `spec/jira/atlassian/jwt_spec.rb`, which fail identically on master.